### PR TITLE
Replicas support

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: retool
-version: 3.1.0
+version: 3.2.0
 maintainers:
   - name: Retool Engineering
     email: engineering@retool.in

--- a/helm/templates/deployment_backend.yaml
+++ b/helm/templates/deployment_backend.yaml
@@ -52,6 +52,10 @@ spec:
         env:
           - name: NODE_ENV
             value: production
+          {{- if gt .Values.replicaCount 1.0 }}
+          - name: SERVICE_TYPE
+            value: MAIN_BACKEND,DB_CONNECTOR
+          {{- end }}
           - name: COOKIE_INSECURE
             value: {{ .Values.config.useInsecureCookies | quote }}
           - name: POSTGRES_HOST
@@ -78,8 +82,6 @@ spec:
                 key: encryption-key
           - name: POSTGRES_USER
             value: {{ template "retool.postgresql.user" . }}
-          - name: POSTGRES_SSL_ENABLED
-            value: {{ template "retool.postgresql.ssl_enabled" . }}
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/helm/templates/deployment_backend.yaml
+++ b/helm/templates/deployment_backend.yaml
@@ -82,6 +82,8 @@ spec:
                 key: encryption-key
           - name: POSTGRES_USER
             value: {{ template "retool.postgresql.user" . }}
+          - name: POSTGRES_SSL_ENABLED
+            value: {{ template "retool.postgresql.ssl_enabled" . }}
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/helm/templates/deployment_jobs.yaml
+++ b/helm/templates/deployment_jobs.yaml
@@ -1,0 +1,159 @@
+{{- if gt .Values.replicaCount 1.0 }}
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "retool.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "retool.fullname" . }}-jobs-runner
+{{- if .Values.deployment.annotations }}
+  annotations:
+{{ toYaml .Values.deployment.annotations | indent 4 }}
+{{- end }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  template:
+    metadata:
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ template "retool.fullname" . }}-jobs-runner
+        release: "{{ .Release.Name }}"
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: {{ template "retool.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+      - name: "{{ $key }}"
+{{ toYaml $value | indent 8 }}
+{{- end }}
+{{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - bash
+          - -c
+          - chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh -t 0 {{ template "retool.postgresql.host" . }}:{{ template "retool.postgresql.port" . }}; ./docker_scripts/start_api.sh
+        {{- if .Values.commandline.args }}
+{{ toYaml .Values.commandline.args | indent 10 }}
+        {{- end }}
+        env:
+          - name: NODE_ENV
+            value: production
+          - name: SERVICE_TYPE
+            value: JOBS_RUNNER
+          - name: COOKIE_INSECURE
+            value: {{ .Values.config.useInsecureCookies | quote }}
+          - name: POSTGRES_HOST
+            value: {{ template "retool.postgresql.host" . }}
+          - name: POSTGRES_PORT
+            value: {{ template "retool.postgresql.port" . }}
+          - name: POSTGRES_DB
+            value: {{ template "retool.postgresql.db" . }}
+          {{- if not .Values.externalSecrets.enabled }}
+          - name: LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "retool.fullname" . }}
+                key: license-key
+          - name: JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "retool.fullname" . }}
+                key: jwt-secret
+          - name: ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "retool.fullname" . }}
+                key: encryption-key
+          - name: POSTGRES_USER
+            value: {{ template "retool.postgresql.user" . }}
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+          {{- if  .Values.postgresql.enabled }}
+                name: {{ template "retool.postgresql.fullname" . }}
+          {{- else  }}
+                name: {{ template "retool.fullname" . }}
+          {{- end }}
+                key: postgresql-password
+          - name: CLIENT_ID
+            value: {{ default "" .Values.config.auth.google.clientId }}
+          - name: CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "retool.fullname" . }}
+                key: google-client-secret
+          - name: RESTRICTED_DOMAIN
+            value: {{ default "" .Values.config.auth.google.domain }}
+          {{- end }}
+          {{- range $key, $value := .Values.env }}
+          - name: "{{ $key }}"
+            value: "{{ $value }}"
+          {{- end }}
+        {{- if .Values.externalSecrets.enabled }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.externalSecrets.name }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        volumeMounts:
+        {{- range $configFile := (keys .Values.files) }}
+        - name: {{ template "retool.name" $ }}
+          mountPath: "/usr/share/retool/config/{{ $configFile }}"
+          subPath: {{ $configFile }}
+        {{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{- end }}
+{{- with .Values.extraContainers }}
+{{ tpl . $ | indent 6 }}
+{{- end }}
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          subPath: {{ .subPath }}
+{{- end }}
+    {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+    {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+{{- end }}
+      volumes:
+{{- range .Values.extraConfigMapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -139,6 +139,8 @@ tolerations: []
 nodeSelector: {}
 
 podAnnotations: {}
+# Increasing replica count will deploy a separate pod for backend and jobs
+# Example: with 3 replicas, you will end up with 3 backends + 1 jobs pod
 replicaCount: 1
 revisionHistoryLimit: 3
 


### PR DESCRIPTION
Jobs deployment template is the copy of backend, with `SERVICE_TYPE=JOBS_RUNNER` and removed port and health checks as it doesn't listen on any port. This template is used only when the number of replicas is > 1. 

There might be some other things to remove from the job template that I'm not aware of.