### PR TITLE
set min cpu/mem resources so the retool api doesn't die in kube

### DIFF
--- a/kubernetes/retool-container.yaml
+++ b/kubernetes/retool-container.yaml
@@ -71,7 +71,12 @@ spec:
         name: api
         ports:
         - containerPort: 3000
-        resources: {}
+        resources:
+          limits:
+            memory: 2048M
+          requests:
+            cpu: "1"
+            memory: 1024M
       restartPolicy: Always
 status: {}
 ---
@@ -95,4 +100,3 @@ spec:
     io.kompose.service: api
 status:
   loadBalancer: {}
-


### PR DESCRIPTION
Fix based on my conversation with @daviddworsky 