### PR TITLE
Updated Deployments to apps/v1 API

### DIFF
--- a/helm/templates/deployment_backend.yaml
+++ b/helm/templates/deployment_backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -14,6 +14,10 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ template "retool.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       annotations:

--- a/helm/templates/deployment_jobs.yaml
+++ b/helm/templates/deployment_jobs.yaml
@@ -1,5 +1,5 @@
 {{- if gt .Values.replicaCount 1.0 }}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -15,6 +15,10 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ template "retool.fullname" . }}-jobs-runner
+      release: {{ .Release.Name }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
The `v1beta` family of Deployment APIs are deprecated and were removed in Kubernetes 1.16.