### PR TITLE
Fix Retool on k8s deployment

### DIFF
--- a/kubernetes/retool-container.yaml
+++ b/kubernetes/retool-container.yaml
@@ -24,7 +24,7 @@ spec:
       - args:
         - bash
         - -c
-        - ./docker_scripts/wait-for-it.sh -t 0 postgres:5432;
+        - ./docker_scripts/wait-for-it.sh -t 0 $POSTGRES_HOST:$POSTGRES_PORT;
           ./docker_scripts/start_api.sh
         env:
         - name: JWT_SECRET


### PR DESCRIPTION
This PR edits the pod spec so that the start script uses the same hostname/port for Postgres as defined in the environment.

Thanks to @Marks-Ed for pairing on this.