### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ We provide Fargate template files supporting [public](/cloudformation/fargate.ya
 
 1. Navigate into the `kubernetes` directory
 2. Copy the `retool-secrets.template.yaml` file to `retool-secrets.yaml` and inside the `{{ ... }}` sections, replace with a suitable base64 encoded string. 
-    1. To base64 encode your license key, run `echo -n '<license key> | base64` in the command line. Be sure to add the `-n` character, as it removes the trailing newline character from the encoding.
+    1. To base64 encode your license key, run `echo -n <license key> | base64` in the command line. Be sure to add the `-n` character, as it removes the trailing newline character from the encoding.
     1. If you do not wish to add google authentication, replace the templates with an empty string.
     1. You will need a license key in order to proceed.
 3. Run `kubectl apply -f ./retool-secrets.yaml`

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ Deploying Retool on-premise ensures that all access to internal data is managed 
     - [ECS + Fargate](#deploying-on-ecs-with-fargate)
     - [Kubernetes](#deploying-on-kubernetes)
     - [Kubernetes + Helm](#deploying-on-kubernetes-with-helm)
-- [Health check endpoint](#health-check-endpoint)
-- [Adding Google login](#adding-google-login)
-- [Integrating with SAML(Okta)](#integrating-with-saml-okta)
-- [Disabling password-based sign-in](#disabling-password-based-sign-in)
-- [Deploy Retool with multiple containers](#deploy-retool-with-multiple-containers)
+- [Login and SSO](#login-and-sso)
+    - [Adding Google login](#adding-google-login)
+    - [Enabling Okta SAML SSO](#enabling-okta-saml-sso)
+    - [Disabling password-based sign-in](#disabling-password-based-sign-in)
+- [Additional features](#additional-features)
+    - [Health check endpoint](#health-check-endpoint)
 - [Troubleshooting](#troubleshooting)
 
 ## Getting started
@@ -263,11 +264,9 @@ helm install ./helm
 
 3. Persistent volumes are not reliable - we recommend that a long-term installation of Retool host the database on an externally managed database like RDS. Please disable the included `postgresql` chart by setting `postgresql.enabled` to `false` and then specifying your external database through the `config.postgresql.*` properties.
 
-## Health check endpoint 
+## Login and SSO
 
-Retool also has a health check endpoint that you can set up to monitor liveliness of Retool. You can configure your probe to make a `GET` request to `/api/checkHealth`.
-
-## Adding Google Login
+### Adding Google Login
 
 Create a Google oauth client using the tutorial below:
 
@@ -288,9 +287,9 @@ Restart the server and you will have Google login for your org!
 
 In Kubernetes, instead of editing the `docker.env` file, place the base64 encoded version of these strings inside the kubernetes secrets file
 
-## Integrating with SAML (Okta)
+### Enabling Okta SAML SSO
 
-Retool also supports SAML authentication schemes. Below is a guide to integrating Retool with Okta.
+Below is a guide to integrating Retool with Okta.
 
 1. Login into Okta as an admin. Make sure to use the Classic UI.
 1. Navigate to the `Applications` section of Okta
@@ -320,7 +319,7 @@ Retool also supports SAML authentication schemes. Below is a guide to integratin
         ```
     1. If you are using Heroku to deploy Retool, add a new environment variable called `SAML_IDP_METADATA` with the value of the XML document. No further steps are required.
 
-## Disabling password-based sign-in
+### Disabling password-based sign-in
 
 To disable the use of email + password sign-in, define the `RESTRICTED_DOMAIN` environment variable. For example, using the `docker.env` file, use this:
 ```
@@ -329,14 +328,11 @@ RESTRICTED_DOMAIN=yourcompany.com
 
 Note that, if you are using this in conjuction with Google login, Retool will compare the value supplied to `RESTRICTED_DOMAIN` with the domain of users that attempt to authenticate with Google SSO and reject accounts from different domains.
 
-## Deploy Retool with Multiple Containers
+## Additional features
 
-Sometimes, you may want to deploy Retool with multiple containers (for ex., if you would like to add resources, or enable git syncing). In addition to the main Retool api container, you will need to add a separate jobs-runner container (which will run migrations + git-syncing, if enabled).
+### Health check endpoint 
 
-1. Add a `SERVICE_TYPE` env var in your main Retool api container, and set its value to `MAIN_BACKEND,DB_CONNECTOR`.
-2. Create a second Retool `jobs-runner` container.
-3. In the `jobs-runner`, set the `SERVICE_TYPE` env var to `JOBS_RUNNER`.
-4. (Re)start your containers.  
+Retool also has a health check endpoint that you can set up to monitor liveliness of Retool. You can configure your probe to make a `GET` request to `/api/checkHealth`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Retool also has a health check endpoint that you can set up to monitor livelines
 - On Kubernetes, I get the error `SequelizeConnectionError: password authentication failed for user "..."`
     - Make sure that the secrets that you encoded in base64 don't have trailing whitespace! You can use `kubectl exec printenv` to help debug this issue.
     - Run `echo -n '<license key> | base64` in the command line. The `-n` character removes the trailing newline character from the encoding.
-- I can't seem to login?
+- I can't seem to login? I keep getting redirected to the login page after signing in.
     - If you have not enabled SSL yet, you will need to add the line `COOKIE_INSECURE=true` to your `docker.env` file / environment configuration so that the authentication cookies can be sent over http. Make sure to run `sudo docker-compose up -d` after modifying the `docker.env` file.
 - `TypeError: Cannot read property 'licenseVerification' of null` or `TypeError: Cannot read property 'name' of null`
     - There is an issue with your license key. Double check that the license key is correct and that it has no trailing whitespaces. 

--- a/README.md
+++ b/README.md
@@ -319,8 +319,12 @@ Retool also has a health check endpoint that you can set up to monitor livelines
 
 - On Kubernetes, I get the error `SequelizeConnectionError: password authentication failed for user "..."`
     - Make sure that the secrets that you encoded in base64 don't have trailing whitespace! You can use `kubectl exec printenv` to help debug this issue.
+    - Run `echo -n '<license key> | base64` in the command line. The `-n` character removes the trailing newline character from the encoding.
 - I can't seem to login?
     - If you have not enabled SSL yet, you will need to add the line `COOKIE_INSECURE=true` to your `docker.env` file / environment configuration so that the authentication cookies can be sent over http. Make sure to run sudo docker-compose up -d after modifying the docker.env file.
+- `TypeError: Cannot read property 'licenseVerification' of null` or `TypeError: Cannot read property 'name' of null`
+    - There is an issue with your license key. Double check that the license key is correct and that it has no trailing whitespaces. 
+
 
 ## Docker cheatsheet
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Retool also has a health check endpoint that you can set up to monitor livelines
 - `TypeError: Cannot read property 'licenseVerification' of null` or `TypeError: Cannot read property 'name' of null`
     - There is an issue with your license key. Double check that the license key is correct and that it has no trailing whitespaces. 
 
-## Releasees
+## Releases
 
 Releases notes can be found on [updates.retool.com](https://updates.retool.com/en).
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Spin up a new EC2 instance. If using AWS, use the following steps:
 1. Run the command `git clone https://github.com/tryretool/retool-onpremise.git`.
 1. Run the command `cd retool-onpremise` to enter the cloned repository's directory.
 1. Run `./install.sh` to install Docker and Docker Compose.
-1. Rename `docker.env.template` to `docker.env` by running: `mv docker.env.template docker.env`.
-1. In your `docker.env` add the following:
+1. In your `docker.env` (file only created after running `./install.sh`) add the following:
     ```
     # License key granted to you by Retool
     LICENSE_KEY=YOUR_LICENSE_KEY 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <p align="center">
-    <a href="https://tryretool.com/"><img src="http://tryretool.com/logo.png" alt="Retool logo" height="100"></a> <br><br>
-<b>Retool lets you build custom internal tools in minutes.</b></p>
-
-
-
+    <a href="https://tryretool.com/"><img src="http://tryretool.com/logo.png" alt="Retool logo" height="100"></a> <br>
+<b>Retool lets you build custom internal tools in minutes.</b></p> <br>
 
 # Deploying Retool on-premise
 
@@ -35,35 +32,20 @@ Get set up in 15 minutes by deploying Retool on a single machine.
 ### Deploying on EC2
 Spin up a new EC2 instance. If using AWS, use the following steps:
 1. Click **Launch Instance** from the EC2 dashboard.
-
-2. Click **Select** for an instance of Ubuntu `16.04` or higher.
-
-3. Select an instance type of at least `t2.medium` and click **Next**.
-
-4. Ensure you select the VPC that also includes the databases / API’s you will want to connect to and click **Next**.
-
-5. Increase the storage size to `60` GB or higher and click **Next**. 
-
-6. Optionally add some Tags (e.g. `app = retool`) and click **Next**. This makes it easier to find if you have a lot of instances.
-
-7. Set the network security groups for ports `80`, `443`, `22` and `3000`, with sources set to `0.0.0.0/0` and `::/0`, and click **Review and Launch**. We need to open ports `80` (http) and `443` (https) so you can connect to the server from a browser, as well as port `22` (ssh) so that you can ssh into the instance to configure it and run Retool. By default on a vanilla EC2, Retool will run on port `3000`. 
-
-8. On the **Review Instance Launch** screen, click **Launch** to start your instance.
-
-9. If you're connecting to internal databases, whitelist the VPS's IP address in your database.
-
-10. From your command line tool, SSH into your EC2 instance.
-
-11. Run the command `git clone https://github.com/tryretool/retool-onpremise.git`.
-
-12. Run the command `cd retool-onpremise` to enter the cloned repository's directory.
-
-13. Run `./install.sh` to install Docker and Docker Compose.
-
-14. Rename `docker.env.template` to `docker.env` by running: `mv docker.env.template docker.env`.
-
-15. In your `docker.env` add the following:
-
+1. Click **Select** for an instance of Ubuntu `16.04` or higher.
+1. Select an instance type of at least `t2.medium` and click **Next**.
+1. Ensure you select the VPC that also includes the databases / API’s you will want to connect to and click **Next**.
+1. Increase the storage size to `60` GB or higher and click **Next**. 
+1. Optionally add some Tags (e.g. `app = retool`) and click **Next**. This makes it easier to find if you have a lot of instances.
+1. Set the network security groups for ports `80`, `443`, `22` and `3000`, with sources set to `0.0.0.0/0` and `::/0`, and click **Review and Launch**. We need to open ports `80` (http) and `443` (https) so you can connect to the server from a browser, as well as port `22` (ssh) so that you can ssh into the instance to configure it and run Retool. By default on a vanilla EC2, Retool will run on port `3000`. 
+1. On the **Review Instance Launch** screen, click **Launch** to start your instance.
+1. If you're connecting to internal databases, whitelist the VPS's IP address in your database.
+1. From your command line tool, SSH into your EC2 instance.
+1. Run the command `git clone https://github.com/tryretool/retool-onpremise.git`.
+1. Run the command `cd retool-onpremise` to enter the cloned repository's directory.
+1. Run `./install.sh` to install Docker and Docker Compose.
+1. Rename `docker.env.template` to `docker.env` by running: `mv docker.env.template docker.env`.
+1. In your `docker.env` add the following:
 ```
 # License key granted to you by Retool
 LICENSE_KEY=YOUR_LICENSE_KEY 
@@ -71,14 +53,10 @@ LICENSE_KEY=YOUR_LICENSE_KEY
 # This is necessary if you plan on logging in before setting up https
 COOKIE_INSECURE=true 
 ```
-
-16. Run `docker-compose up -d` to start the Retool server.
-
-17. Run `sudo docker-compose ps` to make sure all the containers are up and running.
-
-18. Navigate to your server's IP address in a web browser. Retool should now be running on port `3000`.
-
-19. Click Sign Up, since we're starting from a clean slate. The first user to into an instance becomes the administrator. 
+1. Run `docker-compose up -d` to start the Retool server.
+1. Run `sudo docker-compose ps` to make sure all the containers are up and running.
+1. Navigate to your server's IP address in a web browser. Retool should now be running on port `3000`.
+1. Click Sign Up, since we're starting from a clean slate. The first user to into an instance becomes the administrator. 
 
 ### Deploying on Heroku
 
@@ -118,7 +96,6 @@ Alternatively, you may follow the following steps to deploy to Heroku
     1. `HEROKU_HOSTED` set to `true`
     1. `JWT_SECRET`  - set to a long secure random string used to sign JSON Web Tokens
     1. `ENCRYPTION_KEY` - a long secure random string used to encrypt database credentials
-
 1. Push the code: `git push heroku master`
 
 To lockdown the version of Retool used, just edit the first line under `./heroku/Dockerfile` to:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Deploying Retool on-premise ensures that all access to internal data is managed 
     - [Kubernetes + Helm](#deploying-on-kubernetes-with-helm)
 - [Health check endpoint](#health-check-endpoint)
 - [Adding Google login](#adding-google-login)
-- [Integrating with SAML](#integrating-with-saml]
+- [Integrating with SAML](#integrating-with-saml)
 - [Disabling password-based sign-in](#disabling-password-based-sign-in)
 - [Deploy Retool with multiple containers](#deploy-retool-with-multiple-containers)
 - [Troubleshooting](#troubleshooting)

--- a/README.md
+++ b/README.md
@@ -38,11 +38,7 @@ Spin up a new EC2 instance. If using AWS, use the following steps:
 
 2. Click **Select** for an instance of Ubuntu `16.04` or higher.
 
-![Select instance](https://files.readme.io/d5d9fee-ec2_2.jpg)
-
 3. Select an instance type of at least `t2.medium` and click **Next**.
-
-![Instance type](https://files.readme.io/e60e6df-ec2_3.jpg)
 
 4. Ensure you select the VPC that also includes the databases / API’s you will want to connect to and click **Next**.
 
@@ -50,15 +46,11 @@ Spin up a new EC2 instance. If using AWS, use the following steps:
 
 6. Optionally add some Tags (e.g. `app = retool`) and click **Next**. This makes it easier to find if you have a lot of instances.
 
-7. Set the network security groups for ports `80`, `443`, `22` and `3000`, and click **Review and Launch**. We need to open ports `80` (http) and `443` (https) so you can connect to the server from a browser, as well as port `22` (ssh) so that you can ssh into the instance to configure it and run Retool. By default on a vanilla EC2, Retool will run on port `3000`. 
-
-![Add inbound rules](https://files.readme.io/8af8df2-Screen_Shot_2020-12-24_at_4.35.13_PM.png)
+7. Set the network security groups for ports `80`, `443`, `22` and `3000`, with sources set to `0.0.0.0/0` and `::/0`, and click **Review and Launch**. We need to open ports `80` (http) and `443` (https) so you can connect to the server from a browser, as well as port `22` (ssh) so that you can ssh into the instance to configure it and run Retool. By default on a vanilla EC2, Retool will run on port `3000`. 
 
 8. On the **Review Instance Launch** screen, click **Launch** to start your instance.
 
 9. If you're connecting to internal databases, whitelist the VPS's IP address in your database.
-
-![Whitelist IP](https://files.readme.io/331a6f8-Screen_Shot_2019-09-11_at_4.08.31_PM.png)
 
 10. From your command line tool, SSH into your EC2 instance.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Deploying Retool on-premise ensures that all access to internal data is managed 
     - [Kubernetes + Helm](#deploying-on-kubernetes-with-helm)
 - [Health check endpoint](#health-check-endpoint)
 - [Adding Google login](#adding-google-login)
-- [Integrating with SAML(Okta)](#integrating-with-saml-(okta))
+- [Integrating with SAML(Okta)](#integrating-with-saml-okta)
 - [Disabling password-based sign-in](#disabling-password-based-sign-in)
 - [Deploy Retool with multiple containers](#deploy-retool-with-multiple-containers)
 - [Troubleshooting](#troubleshooting)

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Deploying Retool on-premise ensures that all access to internal data is managed 
     - [Kubernetes](#deploying-on-kubernetes)
     - [Kubernetes + Helm](#running-retool-on-kubernetes-with-helm)
 
-# Getting started
+## Getting started
 
-## Running Retool using Docker
+### Running Retool using Docker
 
 1. Install `docker` and `docker-compose`
     1. Provided are two convenience scripts for making it easy to install docker and docker-compose: `./get-docker.sh` and `./get-docker-compose.sh`
@@ -34,24 +34,24 @@ Deploying Retool on-premise ensures that all access to internal data is managed 
 4. Be sure to open up port 80 and port 443 on the virtual machine's host
 5. Navigate to your server's ip address in a web browser to get started.
 
-### Updating Retool using docker-compose
+#### Updating Retool using docker-compose
 
 1. Run `./update_retool.sh`
 1. Alternatively, stop the server, and run `sudo docker-compose pull` and then `sudo docker-compose up -d`
 
-# Simple Deployments
+## Simple Deployments
 
 Get set up in 15 minutes by deploying Retool on a single machine. 
 
-## Deploying on EC2
+### Deploying on EC2
 
-## Deploying to Heroku
+### Deploying to Heroku
 
 Just use the Deploy to Heroku button below!
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-### Updating a Heroku deployment
+#### Updating a Heroku deployment
 
 To update a Heroku deployment that was created with the button above, you may first set up a `git` repo to push to Heroku
 
@@ -69,7 +69,7 @@ $ git commit --allow-empty -m 'Redeploying'
 $ git push heroku master
 ```
 
-### Manually setting up Retool on Heroku
+#### Manually setting up Retool on Heroku
 
 Alternatively, you may follow the following steps to deploy to Heroku
 
@@ -91,7 +91,7 @@ To lockdown the version of Retool used, just edit the first line under `./heroku
 FROM tryretool/backend:X.XX.X
 ```
 
-## Running Retool using Aptible
+### Running Retool using Aptible
 
 1. Add your public SSH key to your Aptible account through the Aptible dashboard
 1. Install the Aptible CLI, and login. Documentation for this can be found here: https://www.aptible.com/documentation/deploy/cli.html
@@ -119,17 +119,17 @@ FROM tryretool/backend:X.XX.X
 1. Create a default Aptible endpoint
 1. Navigate to your endpoint and sign up as a new user in your Retool instance
 
-## Deploying to Render
+### Deploying to Render
 
 Just use the Deploy to Render button below!
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/retool)
 
-# Managed deployments
+## Managed deployments
 
 Deploy Retool on a managed service. We've provided some starter template files for Cloudformation setups (ECS + Fargate), Kubernetes, and Helm. 
 
-## Running Retool on Kubernetes
+### Running Retool on Kubernetes
 
 1. Navigate into the `kubernetes` directory
 2. Copy the `retool-secrets.template.yaml` file to `retool-secrets.yaml` and inside the `{{ ... }}` sections, replace with a suitable base64 encoded string. 
@@ -153,7 +153,7 @@ To force Retool to send the auth cookies over HTTP, please set the `COOKIE_INSEC
 
 Then, to update the running deployment, run `$ kubectl apply -f ./retool-container.yaml`
 
-### Updating Retool on Kubernetes
+#### Updating Retool on Kubernetes
 To update Retool on Kubernetes, you can use the following command:
 
 ```
@@ -164,7 +164,7 @@ $ kubectl set image deploy/api api=tryretool/backend:X.XX.X
 The list of available version numbers for X.XX.X are available here: https://updates.tryretool.com/
 
 
-## Running Retool on Kubernetes with Helm
+### Running Retool on Kubernetes with Helm
 
 1. A helm chart is included in this repository under the ./helm directory
 2. The available parameters are documented using comments in the ./helm/values.yaml file

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Deploying Retool on-premise ensures that all access to internal data is managed 
     - [Kubernetes + Helm](#deploying-on-kubernetes-with-helm)
 - [Health check endpoint](#health-check-endpoint)
 - [Adding Google login](#adding-google-login)
-- [Integrating with SAML](#integrating-with-saml)
+- [Integrating with SAML(Okta)](#integrating-with-saml-(okta))
 - [Disabling password-based sign-in](#disabling-password-based-sign-in)
 - [Deploy Retool with multiple containers](#deploy-retool-with-multiple-containers)
 - [Troubleshooting](#troubleshooting)
@@ -63,23 +63,15 @@ Spin up a new EC2 instance. If using AWS, use the following steps:
 
 4. Ensure you select the VPC that also includes the databases / API’s you will want to connect to and click **Next**.
 
-![Select VPC](https://files.readme.io/5880e1c-databaseAPI.jpg)
-
 5. Increase the storage size to `60` GB or higher and click **Next**. 
 
-![Select storage](https://files.readme.io/051709a-44d7ccf-ec2_4.jpg)
-
 6. Optionally add some Tags (e.g. `app = retool`) and click **Next**. This makes it easier to find if you have a lot of instances.
-
-![Add tags](https://files.readme.io/cc04b7a-tags.jpg)
 
 7. Set the network security groups for ports `80`, `443`, `22` and `3000`, and click **Review and Launch**. We need to open ports `80` (http) and `443` (https) so you can connect to the server from a browser, as well as port `22` (ssh) so that you can ssh into the instance to configure it and run Retool. By default on a vanilla EC2, Retool will run on port `3000`. 
 
 ![Add inbound rules](https://files.readme.io/8af8df2-Screen_Shot_2020-12-24_at_4.35.13_PM.png)
 
 8. On the **Review Instance Launch** screen, click **Launch** to start your instance.
-
-![Review instance](https://files.readme.io/0d1ca93-ec2_6.jpg)
 
 9. If you're connecting to internal databases, whitelist the VPS's IP address in your database.
 
@@ -249,7 +241,7 @@ To force Retool to send the auth cookies over HTTP, please set the `COOKIE_INSEC
 
 Then, to update the running deployment, run `$ kubectl apply -f ./retool-container.yaml`
 
-### Deploying on Kubernetes
+#### Updating Retool on Kubernetes
 To update Retool on Kubernetes, you can use the following command:
 
 ```
@@ -296,7 +288,7 @@ Restart the server and you will have Google login for your org!
 
 In Kubernetes, instead of editing the `docker.env` file, place the base64 encoded version of these strings inside the kubernetes secrets file
 
-## Integrating with SAML
+## Integrating with SAML (Okta)
 
 Retool also supports SAML authentication schemes. Below is a guide to integrating Retool with Okta.
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,8 @@ Below is a cheatsheet for useful Docker commands. Note that you may need to pref
 | `docker-compose up -d`      | Builds, (re)creates, starts, and attaches to containers for a service. `-d`allows containers to run in background (detached). | 
 | `docker-compose down`       | Stops and remove containers and networks                                                                                      |
 | `docker-compose stop`       | Stops containers, but does not remove them and their networks                                                                 |
-| `docker ps -a`              | Display all containers                                                                                                        |
+| `docker ps -a`              | Display all Docker containers                                                                                                 |
+| `docker-compose ps -a`      | Display all containers related to images declared in the `docker-compose` file. 
 | `docker logs <container_id> --follow` | Stream container logs to stdout                                                                                     |
 | `docker exec -it <container_name> psql -U <postgres_user> -W <postgres_password> <postgres_db>` | Runs `psql` inside a container                            |
 | `docker kill $(docker ps -q)` | Kills all running containers                                                                                                |

--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ To update Retool on Kubernetes, you can use the following command:
 
 ```
 $ kubectl set image deploy/api api=tryretool/backend:X.XX.X
-
 ```
 
 The list of available version numbers for X.XX.X are available here: https://updates.tryretool.com/

--- a/README.md
+++ b/README.md
@@ -5,20 +5,26 @@
 
 
 
+# Deploying Retool on-premise
 
+Deploying Retool on-premise ensures that all access to internal data is managed within your own cloud environment. You also have the flexibility to control how Retool is setup within your infrastructure, configure logging, and enable custom SAML SSO using providers like Okta and Active Directory.
 
-# Repository for deploying Retool on-premise
+# Table of contents
+- [Running Retool using Docker](#running-retool-using-docker)
+- [Simple deployments](#simple-deployments)
+    - [EC2 and Docker](#deploying-on-ec2)
+    - [Heroku](#deploying-on-heroku)
+    - [Aptible](#running-retool-using-aptible)
+    - [Render](#deploying-to-render)
+- [Managed deployments](#managed-deployments)
+    - [ECS](#deploying-on-ecs)
+    - [Fargate](#deploying-on-fargate)
+    - [Kubernetes](#deploying-on-kubernetes)
+    - [Kubernetes + Helm](#running-retool-on-kubernetes-with-helm)
 
-Retool can be setup on premise in around 15 minutes. You should use either Docker, Kubernetes, or Heroku. If you're not sure what to use, use Docker.
+# Getting started
 
-## Getting started
-
-### Quick and simple start.
-
-1. Run `./install.sh`to install Docker and Docker Compose
-1. Run `sudo docker-compose up` to start the Retool server
-
-### Running Retool using Docker
+## Running Retool using Docker
 
 1. Install `docker` and `docker-compose`
     1. Provided are two convenience scripts for making it easy to install docker and docker-compose: `./get-docker.sh` and `./get-docker-compose.sh`
@@ -28,62 +34,24 @@ Retool can be setup on premise in around 15 minutes. You should use either Docke
 4. Be sure to open up port 80 and port 443 on the virtual machine's host
 5. Navigate to your server's ip address in a web browser to get started.
 
-#### Updating Retool using docker-compose
+### Updating Retool using docker-compose
 
 1. Run `./update_retool.sh`
 1. Alternatively, stop the server, and run `sudo docker-compose pull` and then `sudo docker-compose up -d`
 
-### Running Retool on Kubernetes with Helm
+# Simple Deployments
 
-1. A helm chart is included in this repository under the ./helm directory
-2. The available parameters are documented using comments in the ./helm/values.yaml file
+Get set up in 15 minutes by deploying Retool on a single machine. 
 
-```
-helm install ./helm
-```
+## Deploying on EC2
 
-3. Persistent volumes are not reliable - we recommend that a long-term installation of Retool host the database on an externally managed database like RDS. Please disable the included `postgresql` chart by setting `postgresql.enabled` to `false` and then specifying your external database through the `config.postgresql.*` properties.
-
-### Running Retool on Kubernetes
-
-1. Navigate into the `kubernetes` directory
-2. Copy the `retool-secrets.template.yaml` file to `retool-secrets.yaml` and inside the `{{ ... }}` sections, replace with a suitable base64 encoded string. To base64 encode your license key, run `echo -n <license key> | base64` in the command line. Be sure to add the `-n` character, as it removes the trailing newline character from the encoding.
-    1. If you do not wish to add google authentication, replace the templates with an empty string.
-    1. You will need a license key in order to proceed.
-3. Run `kubectl apply -f ./retool-secrets.yaml`
-4. Run `kubectl apply -f ./retool-postgres.yaml`
-4. Run `kubectl apply -f ./retool-container.yaml`
-
-For ease of use, this will create a postgres container with a persistent volume for the storage of Retool data. We recommend that you use a managed database service like RDS as a long-term solution. The application will be exposed on a public ip address on port 3000 - we leave it to the user to handle DNS and SSL.
-
-Please note that by default Retool is configured to use Secure Cookies - that means that you will be unable to login unless https has been correctly setup.
-
-To force Retool to send the auth cookies over HTTP, please set the `COOKIE_INSECURE` environment variable to `'true'` in `./retool-container.yaml`. Do this by adding the following two lines to the `env` section.
-
-```
-        - name: COOKIE_INSECURE
-          value: 'true'
-```
-
-Then, to update the running deployment, run `$ kubectl apply -f ./retool-container.yaml`
-
-#### Updating Retool on Kubernetes
-To update Retool on Kubernetes, you can use the following command:
-
-```
-$ kubectl set image deploy/api api=tryretool/backend:X.XX.X
-
-```
-
-The list of available version numbers for X.XX.X are available here: https://updates.tryretool.com/
-
-### Deploying to Heroku
+## Deploying to Heroku
 
 Just use the Deploy to Heroku button below!
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-#### Updating a Heroku deployment
+### Updating a Heroku deployment
 
 To update a Heroku deployment that was created with the button above, you may first set up a `git` repo to push to Heroku
 
@@ -101,7 +69,7 @@ $ git commit --allow-empty -m 'Redeploying'
 $ git push heroku master
 ```
 
-#### Manually setting up Retool on Heroku
+### Manually setting up Retool on Heroku
 
 Alternatively, you may follow the following steps to deploy to Heroku
 
@@ -123,13 +91,7 @@ To lockdown the version of Retool used, just edit the first line under `./heroku
 FROM tryretool/backend:X.XX.X
 ```
 
-### Deploying to Render
-
-Just use the Deploy to Render button below!
-
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/retool)
-
-### Running Retool using Aptible
+## Running Retool using Aptible
 
 1. Add your public SSH key to your Aptible account through the Aptible dashboard
 1. Install the Aptible CLI, and login. Documentation for this can be found here: https://www.aptible.com/documentation/deploy/cli.html
@@ -156,6 +118,62 @@ Just use the Deploy to Render button below!
 1. Push the code: `git push aptible master`
 1. Create a default Aptible endpoint
 1. Navigate to your endpoint and sign up as a new user in your Retool instance
+
+## Deploying to Render
+
+Just use the Deploy to Render button below!
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/retool)
+
+# Managed deployments
+
+Deploy Retool on a managed service. We've provided some starter template files for Cloudformation setups (ECS + Fargate), Kubernetes, and Helm. 
+
+## Running Retool on Kubernetes
+
+1. Navigate into the `kubernetes` directory
+2. Copy the `retool-secrets.template.yaml` file to `retool-secrets.yaml` and inside the `{{ ... }}` sections, replace with a suitable base64 encoded string. 
+    1. To base64 encode your license key, run `echo -n '<license key> | base64` in the command line. Be sure to add the `-n` character, as it removes the trailing newline character from the encoding.
+    1. If you do not wish to add google authentication, replace the templates with an empty string.
+    1. You will need a license key in order to proceed.
+3. Run `kubectl apply -f ./retool-secrets.yaml`
+4. Run `kubectl apply -f ./retool-postgres.yaml`
+4. Run `kubectl apply -f ./retool-container.yaml`
+
+For ease of use, this will create a postgres container with a persistent volume for the storage of Retool data. We recommend that you use a managed database service like RDS as a long-term solution. The application will be exposed on a public ip address on port 3000 - we leave it to the user to handle DNS and SSL.
+
+Please note that by default Retool is configured to use Secure Cookies - that means that you will be unable to login unless https has been correctly setup.
+
+To force Retool to send the auth cookies over HTTP, please set the `COOKIE_INSECURE` environment variable to `'true'` in `./retool-container.yaml`. Do this by adding the following two lines to the `env` section.
+
+```
+        - name: COOKIE_INSECURE
+          value: 'true'
+```
+
+Then, to update the running deployment, run `$ kubectl apply -f ./retool-container.yaml`
+
+### Updating Retool on Kubernetes
+To update Retool on Kubernetes, you can use the following command:
+
+```
+$ kubectl set image deploy/api api=tryretool/backend:X.XX.X
+
+```
+
+The list of available version numbers for X.XX.X are available here: https://updates.tryretool.com/
+
+
+## Running Retool on Kubernetes with Helm
+
+1. A helm chart is included in this repository under the ./helm directory
+2. The available parameters are documented using comments in the ./helm/values.yaml file
+
+```
+helm install ./helm
+```
+
+3. Persistent volumes are not reliable - we recommend that a long-term installation of Retool host the database on an externally managed database like RDS. Please disable the included `postgresql` chart by setting `postgresql.enabled` to `false` and then specifying your external database through the `config.postgresql.*` properties.
 
 ## Health check endpoint 
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ FROM tryretool/backend:X.XX.X
 
 ### Deploying to Render
 
-Just use the Deploy to Render button below!
+Just use the Deploy to Render button below! Here are [some docs](https://render.com/docs/deploy-retool) on deploying Retool with Render.
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/retool)
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Retool also has a health check endpoint that you can set up to monitor livelines
     - Make sure that the secrets that you encoded in base64 don't have trailing whitespace! You can use `kubectl exec printenv` to help debug this issue.
     - Run `echo -n '<license key> | base64` in the command line. The `-n` character removes the trailing newline character from the encoding.
 - I can't seem to login?
-    - If you have not enabled SSL yet, you will need to add the line `COOKIE_INSECURE=true` to your `docker.env` file / environment configuration so that the authentication cookies can be sent over http. Make sure to run sudo docker-compose up -d after modifying the docker.env file.
+    - If you have not enabled SSL yet, you will need to add the line `COOKIE_INSECURE=true` to your `docker.env` file / environment configuration so that the authentication cookies can be sent over http. Make sure to run `sudo docker-compose up -d` after modifying the `docker.env` file.
 - `TypeError: Cannot read property 'licenseVerification' of null` or `TypeError: Cannot read property 'name' of null`
     - There is an issue with your license key. Double check that the license key is correct and that it has no trailing whitespaces. 
 
@@ -330,7 +330,7 @@ Retool also has a health check endpoint that you can set up to monitor livelines
 
 Below is a cheatsheet for useful Docker commands. Note that you may need to prefix them with `sudo`. 
 
-| Command                     | Function                                                                                                                      | 
+| Command                     | Description                                                                                                                     | 
 | ----------------------------|-------------------------------------------------------------------------------------------------------------------------------| 
 | `docker-compose up -d`      | Builds, (re)creates, starts, and attaches to containers for a service. `-d`allows containers to run in background (detached). | 
 | `docker-compose down`       | Stops and remove containers and networks                                                                                      |

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Below is a cheatsheet for useful Docker commands. Note that you may need to pref
 | `docker-compose stop`       | Stops containers, but does not remove them and their networks                                                                 |
 | `docker ps -a`              | Display all Docker containers                                                                                                 |
 | `docker-compose ps -a`      | Display all containers related to images declared in the `docker-compose` file. 
-| `docker logs <container_id> --follow` | Stream container logs to stdout                                                                                     |
+| `docker logs -f <container_name>` | Stream container logs to stdout                                                                                     |
 | `docker exec -it <container_name> psql -U <postgres_user> -W <postgres_password> <postgres_db>` | Runs `psql` inside a container                            |
 | `docker kill $(docker ps -q)` | Kills all running containers                                                                                                |
 | `docker rm $(docker ps -a -q)` | Removes all containers and networks                                                                                        |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Spin up a new EC2 instance. If using AWS, use the following steps:
 1. Run the command `git clone https://github.com/tryretool/retool-onpremise.git`.
 1. Run the command `cd retool-onpremise` to enter the cloned repository's directory.
 1. Run `./install.sh` to install Docker and Docker Compose.
-1. In your `docker.env` (file only created after running `./install.sh`) add the following:
+1. In your `docker.env` (this file is only created after running `./install.sh`) add the following:
     ```
     # License key granted to you by Retool
     LICENSE_KEY=YOUR_LICENSE_KEY 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Spin up a new EC2 instance. If using AWS, use the following steps:
 1. Run `./install.sh` to install Docker and Docker Compose.
 1. Rename `docker.env.template` to `docker.env` by running: `mv docker.env.template docker.env`.
 1. In your `docker.env` add the following:
-```
-# License key granted to you by Retool
-LICENSE_KEY=YOUR_LICENSE_KEY 
+    ```
+    # License key granted to you by Retool
+    LICENSE_KEY=YOUR_LICENSE_KEY 
 
-# This is necessary if you plan on logging in before setting up https
-COOKIE_INSECURE=true 
-```
+    # This is necessary if you plan on logging in before setting up https
+    COOKIE_INSECURE=true 
+    ```
 1. Run `docker-compose up -d` to start the Retool server.
 1. Run `sudo docker-compose ps` to make sure all the containers are up and running.
 1. Navigate to your server's IP address in a web browser. Retool should now be running on port `3000`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 Deploying Retool on-premise ensures that all access to internal data is managed within your own cloud environment. You also have the flexibility to control how Retool is setup within your infrastructure, configure logging, and enable custom SAML SSO using providers like Okta and Active Directory.
 
 # Table of contents
-- [Running Retool using Docker](#running-retool-using-docker)
 - [Simple deployments](#simple-deployments)
     - [EC2 and Docker](#deploying-on-ec2)
     - [Heroku](#deploying-on-heroku)
@@ -28,23 +27,6 @@ Deploying Retool on-premise ensures that all access to internal data is managed 
 - [Additional features](#additional-features)
     - [Health check endpoint](#health-check-endpoint)
 - [Troubleshooting](#troubleshooting)
-
-## Getting started
-
-### Running Retool using Docker
-
-1. Install `docker` and `docker-compose`
-    1. Provided are two convenience scripts for making it easy to install docker and docker-compose: `./get-docker.sh` and `./get-docker-compose.sh`
-2. Run `./docker_setup` and use the default values provided
-    1. If you do not have bash, you can adapt the docker.env.template file
-3. Run `sudo docker-compose up` to start the Retool server
-4. Be sure to open up port 80 and port 443 on the virtual machine's host
-5. Navigate to your server's ip address in a web browser to get started.
-
-#### Updating Retool using docker-compose
-
-1. Run `./update_retool.sh`
-1. Alternatively, stop the server, and run `sudo docker-compose pull` and then `sudo docker-compose up -d`
 
 ## Simple Deployments
 


### PR DESCRIPTION
New Year New README

Adds:
- TOC
- EC2 deployment
- Render deployment link
- ECS 
- ECS + Fargate
- Docker cheatsheet
- A note on release notes

Removes
- Images
- Login and SSO (but links to our docs)
- Running retool with multiple containers