### PR TITLE
[feat] Switch local trial to use a less common port

### DIFF
--- a/docker-compose-local-trial.yml
+++ b/docker-compose-local-trial.yml
@@ -24,7 +24,7 @@ services:
     links:
       - postgres
     ports:
-      - '3000:3000'
+      - '3007:3007'
     volumes:
       - ./keys:/root/.ssh
       - ssh:/retool_backend/autogen_ssh_keys

--- a/docker.env.trial
+++ b/docker.env.trial
@@ -19,8 +19,10 @@ POSTGRES_PASSWORD=randomstring
 
 ## If you wish for Retool to be hosted on a server with a public IP address, then you can use these configs to run the nginx container
 # HOSTNAME=https://retool.company.com
-# DOMAINS=http://localhost -> http://api:3000
+# DOMAINS=http://localhost -> http://api:3007
 
 ## License key
 LICENSE_KEY=LOCAL-ONLY-TRIAL
 COOKIE_INSECURE=true
+
+PORT=3007

--- a/kubernetes/retool-container.yaml
+++ b/kubernetes/retool-container.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1 
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:

--- a/local-trial
+++ b/local-trial
@@ -176,10 +176,8 @@ if retool_trial_running; then
   $MAYBE_SUDO docker-compose down
 fi
 
-if [ ! -f ./docker-compose-ssl.yml ]; then
+if [ ! -f ./docker-compose-ssl.yml ] && [ -f ./docker-compose-local-trial.yml ]; then
   mv docker-compose.yml docker-compose-ssl.yml
-fi
-if [ -f ./docker-compose-local-trial.yml ]; then
   mv docker-compose-local-trial.yml docker-compose.yml
 fi
 
@@ -224,7 +222,7 @@ printf "\r%s%s%s%s%s%s%s%s" "$MAGENTA" 'Check out your ' "$BOLD" 'BROWSER' "${NO
 echo
 
 echo ""
-echo "  ${CYAN}Navigate to${NORMAL}:          ${WHITE}${BOLD}http://localhost:3000/auth/signup${NORMAL}    or    ${WHITE}${BOLD}[publically_accessible_ip]:3000/auth/signup${NORMAL}"
+echo "  ${CYAN}Navigate to${NORMAL}:          ${WHITE}${BOLD}http://localhost:3007/auth/signup${NORMAL}    or    ${WHITE}${BOLD}[publically_accessible_ip]:3007/auth/signup${NORMAL}"
 echo "  ${CYAN}To STOP Retool, run${NORMAL}:  ${WHITE}${BOLD}${DOCKER_CONTEXT}/stop-local-trial${NORMAL}"
 echo "  ${CYAN}To RESTART Retool, run${NORMAL}:  ${WHITE}${BOLD}${DOCKER_CONTEXT}/local-trial${NORMAL}"
 echo ""
@@ -232,5 +230,5 @@ echo ""
 echo "Retool was installed in ~/retool. It will run in the background until you manually stop it. If Retool stops you can restart it without losing your data. "
 
 if command_present open; then
-  open 'http://localhost:3000/auth/signup'
+  open 'http://localhost:3007/auth/signup'
 fi


### PR DESCRIPTION
In response to learnings from build sessions with users that people are likely to have their own services running on 3000 which is then a bad experience when running Retool. 

TODO before merge:

- [ ] Test this on EC2 once PR of listening to port is deployed in 