### PR TITLE
Split out the jobs runner into its own task

### DIFF
--- a/cloudformation/fargate.private.yaml
+++ b/cloudformation/fargate.private.yaml
@@ -94,6 +94,8 @@ Resources:
         Environment:
           - Name: NODE_ENV
             Value: production
+          - Name: SERVICE_TYPE
+            Value: MAIN_BACKEND,DB_CONNECTOR
           - Name: "FORCE_DEPLOYMENT"
             Value: !Ref "Force"
           - Name: POSTGRES_DB
@@ -121,6 +123,54 @@ Resources:
         PortMappings:
         - ContainerPort: '3000'
           # HostPort: '80'
+        Command: ["./docker_scripts/start_api.sh"]
+
+  RetoolJobsRunnerTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      NetworkMode: awsvpc
+      Cpu: '256'
+      Memory: '1024'
+      Family: 'retool'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ExecutionRoleArn: !Ref 'RetoolExecutionRole'
+      RequiresCompatibilities:
+        - FARGATE
+      ContainerDefinitions:
+      - Name: 'retool-jobs-runner'
+        Essential: 'true'
+        Image: !Ref 'Image'
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref 'CloudwatchLogsGroup'
+            awslogs-region: !Ref 'AWS::Region'
+            awslogs-stream-prefix: "SERVICE_RETOOL"
+        Environment:
+          - Name: NODE_ENV
+            Value: production
+          - Name: SERVICE_TYPE
+            Value: JOBS_RUNNER
+          - Name: "FORCE_DEPLOYMENT"
+            Value: !Ref "Force"
+          - Name: POSTGRES_DB
+            Value: hammerhead_production
+          - Name: POSTGRES_HOST
+            Value: !GetAtt [RetoolRDSInstance, Endpoint.Address]
+          - Name: POSTGRES_SSL_ENABLED
+            Value: "true"
+          - Name: POSTGRES_PORT
+            Value: "5432"
+          - Name: POSTGRES_USER
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
+          - Name: POSTGRES_PASSWORD
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
+          - Name: JWT_SECRET
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolJWTSecret, ':SecretString:password}}' ]]
+          - Name: ENCRYPTION_KEY
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
+          - Name: LICENSE_KEY
+            Value: "EXPIRED-LICENSE-KEY-TRIAL"
         Command: ["./docker_scripts/start_api.sh"]
 
   RetoolJWTSecret:
@@ -242,6 +292,16 @@ Resources:
         TargetGroupArn: !Ref 'ECSTG'
       # Role: !Ref 'RetoolServiceRole'
       TaskDefinition: !Ref 'RetoolTask'
+
+  RetoolJobsRunnerECSservice:
+    Type: AWS::ECS::Service
+    DependsOn: RetoolServiceRole
+    Properties:
+      Cluster: !Ref 'Cluster'
+      LaunchType: FARGATE
+      DesiredCount: 1
+      Role: !Ref 'RetoolServiceRole'
+      TaskDefinition: !Ref 'RetoolJobsRunnerTask'
 
   RetoolServiceRole:
     Type: AWS::IAM::Role

--- a/cloudformation/fargate.private.yaml
+++ b/cloudformation/fargate.private.yaml
@@ -295,12 +295,10 @@ Resources:
 
   RetoolJobsRunnerECSservice:
     Type: AWS::ECS::Service
-    DependsOn: RetoolServiceRole
     Properties:
       Cluster: !Ref 'Cluster'
       LaunchType: FARGATE
       DesiredCount: 1
-      Role: !Ref 'RetoolServiceRole'
       TaskDefinition: !Ref 'RetoolJobsRunnerTask'
 
   RetoolServiceRole:

--- a/cloudformation/fargate.yaml
+++ b/cloudformation/fargate.yaml
@@ -297,7 +297,6 @@ Resources:
       Cluster: !Ref 'Cluster'
       DesiredCount: 1
       LaunchType: FARGATE
-      # Role: !Ref 'RetoolServiceRole'
       TaskDefinition: !Ref 'RetoolJobsRunnerTask'
 
   RetoolServiceRole:

--- a/cloudformation/fargate.yaml
+++ b/cloudformation/fargate.yaml
@@ -91,6 +91,8 @@ Resources:
         Environment:
           - Name: NODE_ENV
             Value: production
+          - Name: SERVICE_TYPE
+            Value: MAIN_BACKEND,DB_CONNECTOR
           - Name: "FORCE_DEPLOYMENT"
             Value: !Ref "Force"
           - Name: POSTGRES_DB
@@ -118,6 +120,54 @@ Resources:
         PortMappings:
         - ContainerPort: '3000'
           # HostPort: '80'
+        Command: ["./docker_scripts/start_api.sh"]
+
+  RetoolJobsRunnerTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      NetworkMode: awsvpc
+      Cpu: '256'
+      Memory: '1024'
+      Family: 'retool'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ExecutionRoleArn: !Ref 'RetoolExecutionRole'
+      RequiresCompatibilities:
+        - FARGATE
+      ContainerDefinitions:
+      - Name: 'retool-jobs-runner'
+        Essential: 'true'
+        Image: !Ref 'Image'
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref 'CloudwatchLogsGroup'
+            awslogs-region: !Ref 'AWS::Region'
+            awslogs-stream-prefix: "SERVICE_RETOOL"
+        Environment:
+          - Name: NODE_ENV
+            Value: production
+          - Name: SERVICE_TYPE
+            Value: JOBS_RUNNER
+          - Name: "FORCE_DEPLOYMENT"
+            Value: !Ref "Force"
+          - Name: POSTGRES_DB
+            Value: hammerhead_production
+          - Name: POSTGRES_HOST
+            Value: !GetAtt [RetoolRDSInstance, Endpoint.Address]
+          - Name: POSTGRES_SSL_ENABLED
+            Value: "true"
+          - Name: POSTGRES_PORT
+            Value: "5432"
+          - Name: POSTGRES_USER
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
+          - Name: POSTGRES_PASSWORD
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
+          - Name: JWT_SECRET
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolJWTSecret, ':SecretString:password}}' ]]
+          - Name: ENCRYPTION_KEY
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
+          - Name: LICENSE_KEY
+            Value: "EXPIRED-LICENSE-KEY-TRIAL"
         Command: ["./docker_scripts/start_api.sh"]
 
   RetoolJWTSecret:
@@ -240,6 +290,15 @@ Resources:
         TargetGroupArn: !Ref 'ECSTG'
       # Role: !Ref 'RetoolServiceRole'
       TaskDefinition: !Ref 'RetoolTask'
+
+  RetoolJobsRunnerECSservice:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: 1
+      LaunchType: FARGATE
+      # Role: !Ref 'RetoolServiceRole'
+      TaskDefinition: !Ref 'RetoolJobsRunnerTask'
 
   RetoolServiceRole:
     Type: AWS::IAM::Role

--- a/cloudformation/retool.yaml
+++ b/cloudformation/retool.yaml
@@ -159,9 +159,6 @@ Resources:
             Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
           - Name: LICENSE_KEY
             Value: "EXPIRED-LICENSE-KEY-TRIAL"
-          # Remove below when serving Retool over https
-          - Name: COOKIE_INSECURE
-            Value: "true"
         Command: ["./docker_scripts/start_api.sh"]
 
   RetoolJWTSecret:

--- a/cloudformation/retool.yaml
+++ b/cloudformation/retool.yaml
@@ -87,6 +87,8 @@ Resources:
         Environment:
           - Name: NODE_ENV
             Value: production
+          - Name: SERVICE_TYPE
+            Value: MAIN_BACKEND,DB_CONNECTOR
           - Name: "FORCE_DEPLOYMENT"
             Value: !Ref "Force"
           - Name: POSTGRES_DB
@@ -113,6 +115,53 @@ Resources:
         PortMappings:
         - ContainerPort: '3000'
           HostPort: '80'
+        Command: ["./docker_scripts/start_api.sh"]
+
+  RetoolJobsRunnerTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+      - Name: 'retool-jobs-runner'
+        Cpu: '256'
+        Essential: 'true'
+        Image: !Ref 'Image'
+        Memory: '768'
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref 'CloudwatchLogsGroup'
+            awslogs-region: !Ref 'AWS::Region'
+            awslogs-stream-prefix: "SERVICE_RETOOL"
+        Environment:
+          - Name: NODE_ENV
+            Value: production
+          - Name: SERVICE_TYPE
+            Value: JOBS_RUNNER
+          - Name: "FORCE_DEPLOYMENT"
+            Value: !Ref "Force"
+          - Name: POSTGRES_DB
+            Value: hammerhead_production
+          - Name: POSTGRES_HOST
+            Value: !GetAtt [RetoolRDSInstance, Endpoint.Address]
+          - Name: POSTGRES_SSL_ENABLED
+            Value: "true"
+          - Name: POSTGRES_PORT
+            Value: "5432"
+          - Name: POSTGRES_USER
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
+          - Name: POSTGRES_PASSWORD
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
+          - Name: JWT_SECRET
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolJWTSecret, ':SecretString:password}}' ]]
+          - Name: ENCRYPTION_KEY
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
+          - Name: LICENSE_KEY
+            Value: "EXPIRED-LICENSE-KEY-TRIAL"
+          # Remove below when serving Retool over https
+          - Name: COOKIE_INSECURE
+            Value: "true"
         Command: ["./docker_scripts/start_api.sh"]
 
   RetoolJWTSecret:
@@ -228,6 +277,15 @@ Resources:
         TargetGroupArn: !Ref 'ECSTG'
       Role: !Ref 'RetoolServiceRole'
       TaskDefinition: !Ref 'RetoolTask'
+
+  RetoolJobsRunnerECSservice:
+    Type: AWS::ECS::Service
+    DependsOn: RetoolServiceRole
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: 1
+      Role: !Ref 'RetoolServiceRole'
+      TaskDefinition: !Ref 'RetoolJobsRunnerTask'
 
   RetoolServiceRole:
     Type: AWS::IAM::Role

--- a/cloudformation/retool.yaml
+++ b/cloudformation/retool.yaml
@@ -277,11 +277,9 @@ Resources:
 
   RetoolJobsRunnerECSservice:
     Type: AWS::ECS::Service
-    DependsOn: RetoolServiceRole
     Properties:
       Cluster: !Ref 'Cluster'
       DesiredCount: 1
-      Role: !Ref 'RetoolServiceRole'
       TaskDefinition: !Ref 'RetoolJobsRunnerTask'
 
   RetoolServiceRole:


### PR DESCRIPTION
For production deployments, we recommend that the `jobs-runner` service run in its own container, separated from the resource serving the Retool API / backend.