### PR TITLE
Upgrade to version "3.9" of the Docker Compose file

### DIFF
--- a/docker-compose-local-trial.yml
+++ b/docker-compose-local-trial.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "3.9"
 services:
   api:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "3.9"
 services:
   api:
     build:

--- a/get-docker-compose.sh
+++ b/get-docker-compose.sh
@@ -1,2 +1,2 @@
-sudo -E curl -L https://github.com/docker/compose/releases/download/1.29.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+sudo -E curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
3.9 is supported by Docker Engine [19.03.0+](https://docs.docker.com/engine/release-notes/19.03/#19030), which was first released on July 22, 2019.