### PR TITLE
[fix] don't used encoded folder name for apps not in folder

### DIFF
--- a/testing/generate.js
+++ b/testing/generate.js
@@ -120,7 +120,7 @@ export class RetoolApplication {
 test.use({ storageState: 'state.json' })
 
 test('${folderName ? folderName.replace("'", "") + '/' : ''}${testAppName}', async ({ page }) => {
-  const app = new RetoolApplication(page, "${encodedAppName}", "${encodedFolderName || ''}")
+  const app = new RetoolApplication(page, "${encodedAppName}", "${folderName ? encodedFolderName : ''}")
   await app.test()
 })
 `


### PR DESCRIPTION
only using `encodedFolderName` if the app being tested is in a folder

generated new tests and tested!