### PR TITLE
[feat] create individual tests and group them per app for CI tests

### DIFF
--- a/testing/generate.js
+++ b/testing/generate.js
@@ -88,7 +88,8 @@ export class RetoolApplication {
     await this.page.click('[data-testid="run-all-tests"]')
   }
 
-  async assertResults() {
+  // set singleTest to test name if only testing a single test
+  async assertResults(singleTest) {
     const actual = {}
     const expected = {}
 
@@ -98,18 +99,22 @@ export class RetoolApplication {
     if (results['tests']) {
       results['tests'].forEach(function (test) {
         const testName = test['name']
-        expected[testName] = true
-        actual[testName] = test['passed']
+	
+	if (!(singleTest && singleTest !== testName)) {
+          expected[testName] = true
+          actual[testName] = test['passed']
+        }
       })
     }
 
     expect(actual).toMatchObject(expected)
   }
 
-  async test() {
+  // set singleTest to test name if only testing a single test
+  async test(singleTest) {
     await this.openEditor()
     await this.runAllTests()
-    await this.assertResults()
+    await this.assertResults(singleTest)
   }
 }
 


### PR DESCRIPTION
Creating individual tests for each test for an app and grouping them. Will optimize to only run all tests in a future PR. Currently, each individual test is named after the test name (TBD on whether to add the UUID based on if we make test names unique).