### PR TITLE
[feat] optimize test groups to only run all tests once

### DIFF
--- a/testing/generate.js
+++ b/testing/generate.js
@@ -85,16 +85,16 @@ function playwrightTest(appName, testNames, folderName) {
 
   const individualTests = testNames.map(test =>
 `  test('${test}', async () => {
-    if (fs.existsSync(resultsPath)) {
-      const rawResults = fs.readFileSync(resultsPath)
-      const results = JSON.parse(rawResults.toString())
+    if (!fs.existsSync(resultsPath)) {
+      throw new Error(resultsPath + " does not exist")
+    }
 
-      // only checking for result if test actually had a body and executed
-      if (results['${test}']) {
-        expect(results['${test}']).toBe(true)
-      }
-    } else {
-      console.error(resultsPath + " does not exist")
+    const rawResults = fs.readFileSync(resultsPath)
+    const results = JSON.parse(rawResults.toString())
+
+    // only checking for result if test actually had a body and executed
+    if (results['${test}']) {
+      expect(results['${test}']).toBe(true)
     }
   })`).join('\n\n')
 

--- a/testing/generate.js
+++ b/testing/generate.js
@@ -14,7 +14,7 @@ function globalSetup() {
 import { chromium } from '@playwright/test'
 import * as fs from 'fs'
 
-const resultsDir = 'tmp'
+const resultsDir = 'test-results'
 
 async function globalSetup() {
   const browser = await chromium.launch()
@@ -38,7 +38,7 @@ function globalTeardown() {
   return `// global-teardown.ts
 import * as fs from 'fs'
 
-const resultsDir = 'tmp'
+const resultsDir = 'test-results'
 
 async function globalTeardown() {
   fs.rmdirSync(resultsDir, {recursive: true})
@@ -161,7 +161,7 @@ test.use({ storageState: 'state.json' })
 
 const folderName = '${folderName ? folderName.replace("'", "") : ''}'
 const appName = '${testAppName}'
-const resultsDir = 'tmp'
+const resultsDir = 'test-results'
 const resultsPath = resultsDir + '/' + folderName + '-' + appName + '-test-results.json'
 
 test.describe('${folderName ? folderName.replace("'", "") + '/' : ''}${testAppName}', () => {\n${beforeEachHook}\n\n${individualTests}

--- a/testing/generate.js
+++ b/testing/generate.js
@@ -14,7 +14,7 @@ function globalSetup() {
 import { chromium } from '@playwright/test'
 import * as fs from 'fs'
 
-const resultsDir = 'test-results'
+const resultsDir = 'results'
 
 async function globalSetup() {
   const browser = await chromium.launch()
@@ -38,7 +38,7 @@ function globalTeardown() {
   return `// global-teardown.ts
 import * as fs from 'fs'
 
-const resultsDir = 'test-results'
+const resultsDir = 'results'
 
 async function globalTeardown() {
   fs.rmdirSync(resultsDir, {recursive: true})
@@ -161,7 +161,7 @@ test.use({ storageState: 'state.json' })
 
 const folderName = '${folderName ? folderName.replace("'", "") + '-' : ''}'
 const appName = '${testAppName}'
-const resultsDir = 'test-results'
+const resultsDir = 'results'
 const resultsPath = path.join(resultsDir, folderName +  appName + '-test-results.json')
 
 test.describe('${folderName ? folderName.replace("'", "") + '/' : ''}${testAppName}', () => {\n${beforeEachHook}\n\n${individualTests}

--- a/testing/generate.js
+++ b/testing/generate.js
@@ -159,10 +159,10 @@ export class RetoolApplication {
 
 test.use({ storageState: 'state.json' })
 
-const folderName = '${folderName ? folderName.replace("'", "") : ''}'
+const folderName = '${folderName ? folderName.replace("'", "") + '-' : ''}'
 const appName = '${testAppName}'
 const resultsDir = 'test-results'
-const resultsPath = resultsDir + '/' + folderName + '-' + appName + '-test-results.json'
+const resultsPath = path.join(resultsDir, folderName, appName, '-test-results.json')
 
 test.describe('${folderName ? folderName.replace("'", "") + '/' : ''}${testAppName}', () => {\n${beforeEachHook}\n\n${individualTests}
 })

--- a/testing/generate.js
+++ b/testing/generate.js
@@ -75,15 +75,11 @@ function playwrightTest(appName, testNames, folderName) {
 
   const beforeEachHook =
 `  test.beforeEach(async ({ page }) => {
-    try {
-      if (!fs.existsSync(resultsPath)) {
-        const app = new RetoolApplication(page, "${encodedAppName}", "${folderName ? encodedFolderName : ''}")
-        const results = await app.test()
+    if (!fs.existsSync(resultsPath)) {
+      const app = new RetoolApplication(page, "${encodedAppName}", "${folderName ? encodedFolderName : ''}")
+      const results = await app.test()
 
-        fs.writeFileSync(resultsPath, results)
-      }
-    } catch(err) {
-      console.error(err)
+      fs.writeFileSync(resultsPath, results)
     }
   })`
 

--- a/testing/generate.js
+++ b/testing/generate.js
@@ -12,6 +12,9 @@ function globalSetup() {
   const password = process.env.RETOOL_TEST_PASSWORD || 'password'
   return `// global-setup.ts
 import { chromium } from '@playwright/test'
+import * as fs from 'fs'
+
+const resultsDir = 'tmp'
 
 async function globalSetup() {
   const browser = await chromium.launch()
@@ -23,9 +26,25 @@ async function globalSetup() {
   await page.waitForSelector('.app-browser', {timeout: 180000}) // Wait three minutes for apps to sync
   await page.context().storageState({ path: 'state.json' })
   await browser.close()
+
+  fs.mkdirSync(resultsDir)
 }
 
 export default globalSetup
+`
+}
+
+function globalTeardown() {
+  return `// global-teardown.ts
+import * as fs from 'fs'
+
+const resultsDir = 'tmp'
+
+async function globalTeardown() {
+  fs.rmdirSync(resultsDir, {recursive: true})
+}
+
+export default globalTeardown
 `
 }
 
@@ -35,6 +54,7 @@ function playwrightConfig() {
 const config: PlaywrightTestConfig = {
   testDir: 'tests',
   globalSetup: 'global-setup.ts',
+  globalTeardown: 'global-teardown.ts',
   reporter: 'list',
   workers: 1,
   use: {
@@ -53,13 +73,34 @@ function playwrightTest(appName, testNames, folderName) {
   const encodedFolderName = encodeURIComponent(folderName);
   const testAppName = appName.replace("'", "");
 
+  const beforeEachHook =
+`  test.beforeEach(async ({ page }) => {
+    try {
+      if (!fs.existsSync(resultsPath)) {
+        const app = new RetoolApplication(page, "${encodedAppName}", "${folderName ? encodedFolderName : ''}")
+        const results = await app.test()
+
+        fs.writeFileSync(resultsPath, results)
+      }
+    } catch(err) {
+      console.error(err)
+    }
+  })`
+
   const individualTests = testNames.map(test =>
-`  test('${test}', async ({ page }) => {
-    const app = new RetoolApplication(page, "${encodedAppName}", "${folderName ? encodedFolderName : ''}")
-    await app.test('${test}')
+`  test('${test}', async () => {
+    if (fs.existsSync(resultsPath)) {
+      const rawResults = fs.readFileSync(resultsPath)
+      const results = JSON.parse(rawResults.toString())
+      expect(results['${test}']).toBe(true)
+    } else {
+      console.error(resultsPath + " does not exist")
+    }
   })`).join('\n\n')
 
   return `import { test, expect } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
 
 export class RetoolApplication {
   page: any
@@ -94,39 +135,36 @@ export class RetoolApplication {
     await this.page.click('[data-testid="run-all-tests"]', {timeout: 60000})
   }
 
-  // set singleTest to test name if only testing a single test
-  async assertResults(singleTest) {
+  async assertResults(): Promise<string> {
     const actual = {}
-    const expected = {}
-
     const rawResults = await this.page.getAttribute('[data-testid="all-tests-complete"]', 'data-testResults', {timeout: 60000})
     const results = JSON.parse(rawResults)
 
     if (results['tests']) {
       results['tests'].forEach(function (test) {
         const testName = test['name']
-	
-	if (!(singleTest && singleTest !== testName)) {
-          expected[testName] = true
-          actual[testName] = test['passed']
-        }
+        actual[testName] = test['passed']
       })
     }
 
-    expect(actual).toMatchObject(expected)
+    return JSON.stringify(actual)
   }
 
-  // set singleTest to test name if only testing a single test
-  async test(singleTest) {
+  async test(): Promise<string> {
     await this.openEditor()
     await this.runAllTests()
-    await this.assertResults(singleTest)
+    return await this.assertResults()
   }
 }
 
 test.use({ storageState: 'state.json' })
 
-test.describe('${folderName ? folderName.replace("'", "") + '/' : ''}${testAppName}', () => {\n${individualTests}
+const folderName = '${folderName ? folderName.replace("'", "") : ''}'
+const appName = '${testAppName}'
+const resultsDir = 'tmp'
+const resultsPath = resultsDir + '/' + folderName + '-' + appName + '-test-results.json'
+
+test.describe('${folderName ? folderName.replace("'", "") + '/' : ''}${testAppName}', () => {\n${beforeEachHook}\n\n${individualTests}
 })
 `
 }
@@ -140,6 +178,7 @@ function main() {
 
   fs.writeFileSync(path.join(workingDir, 'global-setup.ts'), globalSetup());
   fs.writeFileSync(path.join(workingDir, 'playwright.config.ts'), playwrightConfig());
+  fs.writeFileSync(path.join(workingDir, 'global-teardown.ts'), globalTeardown());
 
   try {
     fs.mkdirSync(path.join(workingDir, 'tests'));

--- a/testing/generate.js
+++ b/testing/generate.js
@@ -162,7 +162,7 @@ test.use({ storageState: 'state.json' })
 const folderName = '${folderName ? folderName.replace("'", "") + '-' : ''}'
 const appName = '${testAppName}'
 const resultsDir = 'test-results'
-const resultsPath = path.join(resultsDir, folderName, appName, '-test-results.json')
+const resultsPath = path.join(resultsDir, folderName +  appName + '-test-results.json')
 
 test.describe('${folderName ? folderName.replace("'", "") + '/' : ''}${testAppName}', () => {\n${beforeEachHook}\n\n${individualTests}
 })

--- a/testing/generate.js
+++ b/testing/generate.js
@@ -92,7 +92,11 @@ function playwrightTest(appName, testNames, folderName) {
     if (fs.existsSync(resultsPath)) {
       const rawResults = fs.readFileSync(resultsPath)
       const results = JSON.parse(rawResults.toString())
-      expect(results['${test}']).toBe(true)
+
+      // only checking for result if test actually had a body and executed
+      if (results['${test}']) {
+        expect(results['${test}']).toBe(true)
+      }
     } else {
       console.error(resultsPath + " does not exist")
     }


### PR DESCRIPTION
As discussed with @kyle-retool, currently when tests are grouped, each individual test requires building the environment, opening the application, and running all tests, which is inefficient. Instead, this approach only runs once before all tests are run and writes the results to a temporary file store in `tmp/`. Each individual test simply reads this file (and does not re-run the application). 

![image](https://user-images.githubusercontent.com/3528894/128763707-4a827179-4853-496a-af42-f38c9ee1ef71.png)

First test in a group takes a normal amount of time but subsequent tests run in the order of milliseconds