### PR TITLE
[feat] increase timeouts for getAttribute from 60s to 120s

### DIFF
--- a/testing/generate.js
+++ b/testing/generate.js
@@ -137,7 +137,7 @@ export class RetoolApplication {
 
   async assertResults(): Promise<string> {
     const actual = {}
-    const rawResults = await this.page.getAttribute('[data-testid="all-tests-complete"]', 'data-testResults', {timeout: 60000})
+    const rawResults = await this.page.getAttribute('[data-testid="all-tests-complete"]', 'data-testResults', {timeout: 120000})
     const results = JSON.parse(rawResults)
 
     if (results['tests']) {

--- a/testing/generate.js
+++ b/testing/generate.js
@@ -132,7 +132,7 @@ export class RetoolApplication {
     await this.page.click('[data-testid="open-tests-modal"]')
 
     // Click [data-testid="run-all-tests"]
-    await this.page.click('[data-testid="run-all-tests"]', {timeout: 60000})
+    await this.page.click('[data-testid="run-all-tests"]', {timeout: 120000})
   }
 
   async assertResults(): Promise<string> {


### PR DESCRIPTION
All flakey tests run involves timeouts on `getAttribute` or clicking the 'Run All Tests' button --> can bump up the timeout on that function to see if timeout is truly the constraint or the 'Run All Tests' button is just never getting enabled.