### PR TITLE
[fix][ENT-1723] mount ./keys directory in jobs-runner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
       - postgres
     volumes:
       - ./keys:/root/.ssh
-      - ./retool:/usr/local/retool-git-repo
       
   db-connector:
     build:


### PR DESCRIPTION
According to the [readme located in the ./keys directory](https://github.com/tryretool/retool-onpremise/blob/master/keys/README.md), you should be able to place a key pair there, and it will be used for git syncing. This did not work, because the jobs-runner was not mounting this folder, so it did not have access to the keys.

Added a volume mount to the container definition to fix this.