### PR TITLE
Add https portal 600s timeouts to https portal component

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,10 +113,10 @@ services:
     env_file: ./docker.env
     environment:
       STAGE: 'local' # <- Change 'local' to 'production' to use a LetsEncrypt signed SSL cert
-      KEEPALIVE_TIMEOUT: 125
-      PROXY_CONNECT_TIMEOUT: 120
-      PROXY_SEND_TIMEOUT: 120
-      PROXY_READ_TIMEOUT: 120
+      KEEPALIVE_TIMEOUT: 605
+      PROXY_CONNECT_TIMEOUT: 600
+      PROXY_SEND_TIMEOUT: 600
+      PROXY_READ_TIMEOUT: 600
     networks:
       - frontend-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,10 @@ services:
     env_file: ./docker.env
     environment:
       STAGE: 'local' # <- Change 'local' to 'production' to use a LetsEncrypt signed SSL cert
+      KEEPALIVE_TIMEOUT: 65
+      PROXY_CONNECT_TIMEOUT: 60
+      PROXY_SEND_TIMEOUT: 60
+      PROXY_READ_TIMEOUT: 60
     networks:
       - frontend-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,10 +113,10 @@ services:
     env_file: ./docker.env
     environment:
       STAGE: 'local' # <- Change 'local' to 'production' to use a LetsEncrypt signed SSL cert
-      KEEPALIVE_TIMEOUT: 65
-      PROXY_CONNECT_TIMEOUT: 60
-      PROXY_SEND_TIMEOUT: 60
-      PROXY_READ_TIMEOUT: 60
+      KEEPALIVE_TIMEOUT: 125
+      PROXY_CONNECT_TIMEOUT: 120
+      PROXY_SEND_TIMEOUT: 120
+      PROXY_READ_TIMEOUT: 120
     networks:
       - frontend-network
 


### PR DESCRIPTION
The defaults for https-portal: https://github.com/SteveLTN/https-portal#configure-nginx-through-environment-variables

I am adding these to docker-compose.yml so that it will be easier to find in the future. It has been difficult to find the https-portal repo and to figure out how to configure its nginx.