### PR TITLE
Increase default storage for postgres container

### DIFF
--- a/kubernetes/retool-postgres.yaml
+++ b/kubernetes/retool-postgres.yaml
@@ -10,7 +10,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 60Gi
 status: {}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
https://docs.retool.com/docs/configuring-retools-storage-database indicates that 60gb should be the minimum to accommodate log scaling.