### PR TITLE
Set CLIENT_MAX_BODY_SIZE to 40MB in https-portal environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     env_file: ./docker.env
     environment:
       STAGE: 'local' # <- Change 'local' to 'production' to use a LetsEncrypt signed SSL cert
-      CLIENT_MAX_BODY_SIZE: 1G
+      CLIENT_MAX_BODY_SIZE: 40M
       KEEPALIVE_TIMEOUT: 605
       PROXY_CONNECT_TIMEOUT: 600
       PROXY_SEND_TIMEOUT: 600

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
     env_file: ./docker.env
     environment:
       STAGE: 'local' # <- Change 'local' to 'production' to use a LetsEncrypt signed SSL cert
+      CLIENT_MAX_BODY_SIZE: 1G
     networks:
       - frontend-network
 


### PR DESCRIPTION
Default is 1M https://github.com/SteveLTN/https-portal#configure-nginx-through-environment-variables

Common on-prem customer support issue.

See: https://linear.app/retool/issue/CXN-632/file-attachment-gives-413-error

The cloud default is 40M.