### PR TITLE
feat: add single quotes for DOMAINS variable

### DIFF
--- a/docker_setup
+++ b/docker_setup
@@ -44,7 +44,7 @@ echo "POSTGRES_PASSWORD=${postgresPassword}" >> docker.env
 echo '' >> docker.env
 
 echo "# Change '${hostname}' to retool.yourcompany.com to set up SSL properly" >> docker.env
-echo "DOMAINS=${hostname} -> http://api:3000" >> docker.env
+echo "DOMAINS='${hostname} -> http://api:3000'" >> docker.env
 echo '' >> docker.env
 
 echo '## Used to create links for your users, like new user invitations and forgotten password resets' >> docker.env


### PR DESCRIPTION
The DOMAINS environment variable in `docker.env` must be set with single quotes. For example,
```
DOMAINS='dev.candidcabbage.com -> http://api:3000'
```
will resolve properly, while
```
DOMAINS=dev.candidcabbage.com -> http://api:3000
```
will not resolve properly.

---
More generally, I think we should modify [`docker_setup`](https://github.com/tryretool/retool-onpremise/blob/master/docker_setup) to copy [`docker.env.template`](https://github.com/tryretool/retool-onpremise/blob/master/docker.env.template), rather than reproducing the file [through `echo` commands.](https://github.com/tryretool/retool-onpremise/blob/master/docker_setup#L28)
