### PR TITLE
Refactor networking env vars in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,6 @@ services:
     restart: always
     env_file: ./docker.env
     environment:
-      STAGE: 'local' # <- Change 'local' to 'production' to use a LetsEncrypt signed SSL cert
       CLIENT_MAX_BODY_SIZE: 40M
       KEEPALIVE_TIMEOUT: 605
       PROXY_CONNECT_TIMEOUT: 600

--- a/docker_setup
+++ b/docker_setup
@@ -44,12 +44,10 @@ echo "POSTGRES_PASSWORD=${postgresPassword}" >> docker.env
 echo '' >> docker.env
 
 echo "# Change '${hostname}' to retool.yourcompany.com to set up SSL properly" >> docker.env
+echo "STAGE='local'" >> docker.env
 echo "DOMAINS=${hostname} -> http://api:3000" >> docker.env
-echo '' >> docker.env
-
-echo '## Used to create links for your users, like new user invitations and forgotten password resets' >> docker.env
-echo '## The backend tries to guess this, but it can be incorrect if there’s a proxy in front of the website' >> docker.env
 echo '# BASE_DOMAIN=https://retool.yourwebsite.com' >> docker.env
+echo '# COOKIE_INSECURE=true' >> docker.env 
 echo '' >> docker.env
 
 echo '## Set key to encrypt and decrypt database passwords, etc.' >> docker.env
@@ -64,7 +62,6 @@ echo '## License key' >> docker.env
 echo 'LICENSE_KEY=EXPIRED-LICENSE-KEY-TRIAL' >> docker.env
 echo '' >> docker.env
 
-echo '## Uncomment this line if HTTPS is not set up' >> docker.env
-echo '# COOKIE_INSECURE=true' >> docker.env 
+
 
 echo "Cool! Now add your license key in docker.env then run docker-compose up to launch Retool."


### PR DESCRIPTION
Refactor networking env vars in docker compose
---
In `docker compose` deployments, networking between the host machine and the docker containers is implemented by
the **[https-portal](https://github.com/SteveLTN/https-portal)**. The behavior of the http server is governed by three  environment variables: `STAGE`, `DOMAIN`, and `COOKIE_INSECURE`. Currently, the `STAGE` variable is set in `docker-compose.yml`.

This PR moves the `STAGE` variable to `docker.env` and groups it with the rest of the networking env vars.

```
#docker.env

...

## Instance networking
STAGE='local'
DOMAINS='54.186.188.167 -> http://api:3000'
# BASE_DOMAIN=https://dev.candidcabbage.com
# COOKIE_INSECURE=true
```

Changes implemented :
* Remove `STAGE='local'` from `docker-compose.yml`
* Add `STAGE='local' to the generated `docker.env`
* Refactor `docker_setup` to group networking variables together