### PR TITLE
add rds subnet groups to CF templates

### DIFF
--- a/cloudformation/fargate.private.yaml
+++ b/cloudformation/fargate.private.yaml
@@ -60,6 +60,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'database security group']]
+      VpcId: !Ref 'VpcId'
 
   RetoolECSPostgresInbound:
     Type: AWS::EC2::SecurityGroupIngress
@@ -217,6 +218,13 @@ Resources:
       Port: "5432"
       PubliclyAccessible: true
       VPCSecurityGroups: [!GetAtt [RDSSecurityGroup, GroupId]]
+      DBSubnetGroupName: !Ref 'RDSSubnetGroup'
+
+  RDSSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties: 
+      DBSubnetGroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'rds subnet security group']]
+      SubnetIds: !Ref 'SubnetId' 
 
   ECSALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer

--- a/cloudformation/fargate.private.yaml
+++ b/cloudformation/fargate.private.yaml
@@ -216,7 +216,6 @@ Resources:
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
       Port: "5432"
-      PubliclyAccessible: true
       VPCSecurityGroups: [!GetAtt [RDSSecurityGroup, GroupId]]
       DBSubnetGroupName: !Ref 'RDSSubnetGroup'
 

--- a/cloudformation/fargate.yaml
+++ b/cloudformation/fargate.yaml
@@ -57,6 +57,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'database security group']]
+      VpcId: !Ref 'VpcId'
 
   RetoolECSPostgresInbound:
     Type: AWS::EC2::SecurityGroupIngress
@@ -214,6 +215,13 @@ Resources:
       Port: "5432"
       PubliclyAccessible: true
       VPCSecurityGroups: [!GetAtt [RDSSecurityGroup, GroupId]]
+      DBSubnetGroupName: !Ref 'RDSSubnetGroup'
+
+  RDSSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties: 
+      DBSubnetGroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'rds subnet security group']]
+      SubnetIds: !Ref 'SubnetId'
 
   ECSALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer

--- a/cloudformation/fargate.yaml
+++ b/cloudformation/fargate.yaml
@@ -213,7 +213,6 @@ Resources:
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
       Port: "5432"
-      PubliclyAccessible: true
       VPCSecurityGroups: [!GetAtt [RDSSecurityGroup, GroupId]]
       DBSubnetGroupName: !Ref 'RDSSubnetGroup'
 

--- a/cloudformation/fargate.yaml
+++ b/cloudformation/fargate.yaml
@@ -304,7 +304,6 @@ Resources:
     Properties:
       NetworkConfiguration:
         AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
           SecurityGroups: [!Ref 'ALBSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'

--- a/cloudformation/fargate.yaml
+++ b/cloudformation/fargate.yaml
@@ -304,6 +304,7 @@ Resources:
     Properties:
       NetworkConfiguration:
         AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
           SecurityGroups: [!Ref 'ALBSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'

--- a/cloudformation/retool.yaml
+++ b/cloudformation/retool.yaml
@@ -204,7 +204,6 @@ Resources:
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
       MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
       Port: "5432"
-      PubliclyAccessible: true
       VPCSecurityGroups: [!GetAtt [RDSSecurityGroup, GroupId]]
       DBSubnetGroupName: !Ref 'RDSSubnetGroup'
 

--- a/cloudformation/retool.yaml
+++ b/cloudformation/retool.yaml
@@ -57,6 +57,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'database security group']]
+      VpcId: !Ref 'VpcId'
 
   RetoolECSPostgresInbound:
     Type: AWS::EC2::SecurityGroupIngress
@@ -205,6 +206,13 @@ Resources:
       Port: "5432"
       PubliclyAccessible: true
       VPCSecurityGroups: [!GetAtt [RDSSecurityGroup, GroupId]]
+      DBSubnetGroupName: !Ref 'RDSSubnetGroup'
+
+  RDSSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties: 
+      DBSubnetGroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'rds subnet security group']]
+      SubnetIds: !Ref 'SubnetId' 
 
   ECSALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer


### PR DESCRIPTION
add rds subnet groups to CF templates to support deploying in non-default vpc's 