### PR TITLE
Update Heroku steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ You can manually deploy to Heroku using the following steps:
    1. `USE_GCM_ENCRYPTION` set to `true` for authenticated encryption of secrets; if true, `ENCRYPTION_KEY` must be 24 bytes
    1. `LICENSE_KEY` - your Retool license key
    1. `PGSSLMODE` - set to `require`
-1. _Optional_: To lockdown the version of Retool used, just edit the first line
+1. _Optional_: To select the version of Retool used, just edit the first line
    under `./heroku/Dockerfile` to:
    ```docker
    FROM tryretool/backend:X.Y.Z

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ You can manually deploy to Heroku using the following steps:
 1. Add a database: `heroku addons:create heroku-postgresql:mini`
 1. In the `Settings` page of your Heroku app, add the following environment variables:
    1. `NODE_ENV` - set to `production`
-   1. `HEROKU_HOSTED` set to `true`
    1. `JWT_SECRET` - set to a long secure random string used to sign JSON Web Tokens
    1. `ENCRYPTION_KEY` - a long secure random string used to encrypt database credentials
    1. `USE_GCM_ENCRYPTION` set to `true` for authenticated encryption of secrets; if true, `ENCRYPTION_KEY` must be 24 bytes

--- a/README.md
+++ b/README.md
@@ -166,13 +166,30 @@ Spin up a new EC2 instance. If using AWS, use the following steps:
 
 ### Deploying Retool on Heroku
 
+#### Automatic deploy
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/tryretool/retool-onpremise)
+
+You can deploy to Heroku using the following steps:
+
+1. Click the button above to begin your deployment
+1. Provide a unique App name, e.g. `<your-org>-retool`
+1. Provide required config vars:
+    * `LICENSE_KEY` - your Retool license key
+1. Set any optional config vars:
+    * `USE_GCM_ENCRYPTION` set to `true` for authenticated encryption of
+      secrets; if true, `ENCRYPTION_KEY` must be 24 bytes
+1. Click "Deploy app"
+
+#### Manual deploy
+
 You can manually deploy to Heroku using the following steps:
 
 1. Install the Heroku CLI, and login. Documentation for this can be found here: <https://devcenter.heroku.com/articles/getting-started-with-nodejs#set-up>
 1. Clone this repo `git clone https://github.com/tryretool/retool-onpremise`
 1. Change the working directory to the newly cloned repository `cd ./retool-onpremise`
 1. Create a new Heroku app with the stack set to `container` with `heroku create your-app-name --stack=container`
-1. Add a free database: `heroku addons:create heroku-postgresql:hobby-dev`
+1. Add a database: `heroku addons:create heroku-postgresql:mini`
 1. In the `Settings` page of your Heroku app, add the following environment variables:
    1. `NODE_ENV` - set to `production`
    1. `HEROKU_HOSTED` set to `true`
@@ -181,13 +198,12 @@ You can manually deploy to Heroku using the following steps:
    1. `USE_GCM_ENCRYPTION` set to `true` for authenticated encryption of secrets; if true, `ENCRYPTION_KEY` must be 24 bytes
    1. `LICENSE_KEY` - your Retool license key
    1. `PGSSLMODE` - set to `require`
+1. _Optional_: To lockdown the version of Retool used, just edit the first line
+   under `./heroku/Dockerfile` to:
+   ```docker
+   FROM tryretool/backend:X.Y.Z
+   ```
 1. Push the code: `git push heroku master`
-
-To lockdown the version of Retool used, just edit the first line under `./heroku/Dockerfile` to:
-
-```docker
-FROM tryretool/backend:X.Y.Z
-```
 
 ### Deploying Retool using Aptible
 
@@ -382,19 +398,16 @@ kubectl set image deploy/api api=tryretool/backend:X.Y.Z
 
 ### Heroku deployments
 
-To update a Heroku deployment that was created with the button above, you may first set up a `git` repo to push to Heroku
+To update a Heroku deployment that was created with the button above, you'll
+need to push the desired changes to the Heroku remote.
 
 ```zsh
-heroku login
-git clone https://github.com/tryretool/retool-onpremise
-cd retool-onpremise
-heroku git:remote -a YOUR_HEROKU_APP_NAME
-```
-
-To update Retool (this will automatically fetch the latest version of Retool)
-
-```zsh
-git commit --allow-empty -m 'Redeploying'
+# This assumes you already have the `heroku` CLI installed and are logged in
+heroku git:clone --app=<your-retool-app-name> # default remote name is "heroku"
+git remote add upstream https://github.com/tryretool/retool-onpremise
+# This will incpororate the remote changes into your _local_ copy
+# Also assumes both branches are "master"
+git pull upstream master
 git push heroku master
 ```
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ You can manually deploy to Heroku using the following steps:
 1. Create a new Aptible app with `aptible apps:create your-app-name`
 1. Add a database: `aptible db:create your-database-name --type postgresql`
 1. Set your config variables (your database connection string will be in your Aptible Dashboard and you can parse out the individual values by following [these instructions](https://www.aptible.com/documentation/deploy/reference/databases/credentials.html#using-database-credentials)). Be sure to rename `EXPIRED-LICENSE-KEY-TRIAL` to the license key provided to you.
-1. If secrets need an authenticated encryption method, add `USE_GCM_ENCRYTPION=true` to the command below and change `ENCRYPTION_KEY=$(cat /dev/urandom | base64 | head -c 24)`
+1. If secrets need an authenticated encryption method, add `USE_GCM_ENCRYPTION=true` to the command below and change `ENCRYPTION_KEY=$(cat /dev/urandom | base64 | head -c 24)`
 
    ```yml
    aptible config:set --app your-app-name \

--- a/app.json
+++ b/app.json
@@ -19,15 +19,6 @@
       "required": true,
       "generator": "secret"
     },
-    "HEROKU_HOSTED": {
-      "required": true,
-      "value": "true"
-    },
-    "HOST_ENV": {
-      "description": "Whether service is hosted by Heroku or not",
-      "required": true,
-      "value": "HEROKU"
-    },
     "JWT_SECRET": {
       "description": "A secret key for signing JSON Web Tokens",
       "required": true,

--- a/app.json
+++ b/app.json
@@ -1,29 +1,62 @@
 {
   "name": "retool",
-  "description": "Retool heroku",
+  "description": "Retool Heroku",
+  "keywords": [
+    "retool"
+  ],
+  "logo": "https://avatars.githubusercontent.com/u/33817679",
+  "repository": "https://github.com/tryretool/retool-onpremise",
   "stack": "container",
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "performance-m"
+    }
+  },
   "env": {
-    "NODE_ENV": {
-      "description": "The environment to run Retool",
-      "value": "production"
+    "ENCRYPTION_KEY": {
+      "description": "A secret key for encrypting secret credentials when connecting Retool to other databases or API endpoints",
+      "required": true,
+      "generator": "secret"
+    },
+    "HEROKU_HOSTED": {
+      "required": true,
+      "value": "true"
     },
     "HOST_ENV": {
       "description": "Whether service is hosted by Heroku or not",
+      "required": true,
       "value": "HEROKU"
     },
     "JWT_SECRET": {
       "description": "A secret key for signing JSON Web Tokens",
+      "required": true,
       "generator": "secret"
     },
-    "ENCRYPTION_KEY": {
-      "description": "A secret key for encrypting secret credentials when connecting Retool to other databases or API endpoints",
-      "generator": "secret"
+    "LICENSE_KEY": {
+      "description": "Your Retool license key",
+      "required": true
+    },
+    "NODE_ENV": {
+      "description": "The environment to run Retool",
+      "required": true,
+      "value": "production"
+    },
+    "PGSSLMODE": {
+      "required": true,
+      "value": "require"
+    },
+    "USE_GCM_ENCRYPTION": {
+      "description": "Set to `true` for authenticated encryption of secrets",
+      "required": false
     }
   },
-  "addons": [{
-    "plan": "heroku-postgresql",
-    "options": {
-      "version": "11"
+  "addons": [
+    {
+      "plan": "heroku-postgresql:standard-0",
+      "options": {
+        "version": "11"
+      }
     }
-  }]
+  ]
 }


### PR DESCRIPTION
👋 Hey there, sorry if this is a presumptuous PR.
This includes some changes to the Heroku deploy flow that I felt helped stream-line our own process. Rationale behind the key changes:

* Update `app.json` with a number of additional fields to try and make auto-deploy faster
    * Include a number of additional env variables
    * Bump the default dyno size to `performance-m` which is the smallest size I've seen to assuage Heroku memory errors, i.e. R14 & R15
    * Bump the default postgres size to `standard-0`. It's the first tier to include encryption at rest. Further, you cannot use `heroku addons:upgrade` when going from essential -> other tiers
* Include a Heroku deploy button
    * This uses the `app.json` file heavily. Only need to provide the license key now
    * To test before merging, you'll need to change the `template` param to `https://github.com/ed-flanagan/retool-onpremise/tree/update-for-heroku` (i.e. where the `app.json` changes currently live)
* Update the Heroku update flow
    * I didn't feel we needed the empty commit messages to re-deploy the application
    * Change method to (1) clone the current app, (2) `pull` in upstream changes, and (3) push up to Heroku
    * This method assumes you're strictly basing of upstream's HEAD. Happy to include an additional section if you're maintaining a different repo. I.e. doing a `merge` strategy

Happy to update whatever. Throwing up in-case there was any interest.
This may also help close #86 

I saw some other variables throughout the README and wasn't sure if they'd be relevant for the Heroku deployment. `BASE_DOMAIN`, `FORCE_SSL`, and `COOKIE_INSECURE` (probably don't need this with Heroku https?)

---

* Update README
    * Deploy
        * Provide a "Deploy to Heroku" button
        * Create sub sections for auto & manual deploy
        * Format existing instructions
        * Incorporate ad hoc Docker changes to manual steps
        * Change manual addon plan to "mini" (no more free tier EOM)
    * Update
        * Change steps as to not require an empty commit
        * Include steps for when working strictly off upstream version
* Update app.json
    * Nit: capitalize "Heroku"
    * Add keywords
    * Add logo
    * Add repository
    * Add formation
    * Update env
        * Sort existing values
        * Add required field for some
        * Add additional env values
    * Update addons block
        * Nit: format
        * Change default postgres plan to "standard-0"
* `s/USE_GCM_ENCRYTPION/USE_GCM_ENCRYPTION/`