### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 - [Select a Retool version number](#select-a-retool-version-number)
 - [One-Click Deploy](#one-click-deploy)
+  - [AWS](#one-click-deployment-to-aws)
   - [Render](#one-click-deployment-to-render)
 - [Single deployments](#single-deployments)
   - [General Machine Specifications](#general-machine-specifications)
@@ -43,7 +44,7 @@ To help you select a version, see our guide on [Retool Release Versions](https:/
 
 ## One-Click Deploy
 
-### One-click Deployment to AWS (CloudFormation + EC2)
+### One-click Deployment to AWS
 
 Region name | Region code | Launch
 --- | --- | ---


### PR DESCRIPTION
The ToC fails to highlight AWS; a quick scan of `README.md` would suggest we only support a one-click install to Render.

Details:
* Add href/link to AWS detail (get AWS into the ToC)
* Drop CloudFormation/EC2 detail

If we feel like it it's useful to preserve the CloudFormation/EC2 detail, let's do it w/in the AWS section.
