### PR TITLE
Fix ssop start up

### DIFF
--- a/deploy-retool
+++ b/deploy-retool
@@ -82,7 +82,7 @@ DOCKER_CONTEXT="$INSTALL_DIRECTORY/retool-onpremise"
 
 cd "$HOME"
 
-if [ ! -d "$DOCKER_CONTEXT" ]; then
+if [ ! -d "$DOCKER_CO$NTEXT" ]; then
   if [ -d "$INSTALL_DIRECTORY" ]; then
     log_step 'found a partial install, cleaning it up...'
     rm -rf "$INSTALL_DIRECTORY"
@@ -124,67 +124,68 @@ if [ ! -d "$DOCKER_CONTEXT" ]; then
   read -p "Enter your license key: " licenseKey
   echo "LICENSE_KEY=$licenseKey" >> docker.env
 
-  if ! command_present docker; then
-    # shellcheck disable=2016
-    log_warn '`docker` not found! Attempting to install. This may take a few minutes.'
-    ./get-docker.sh
-
-    if ! command_present docker; then
-      if [[ "$OSTYPE" == "darwin"* ]]; then
-        error_exit "please install \`docker\` manually" \
-          "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
-          "${BOLD}Remember${NORMAL} to start the \`Docker\` app from the UI."
-      else
-        error_exit "please install \`docker\` manually" \
-          "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
-          "${BOLD}Remember${NORMAL} to start the \`docker\` daemon/service."
-      fi
-    fi
-  else
-    # shellcheck disable=2016
-    log_step '`docker` found!'
-  fi
-
-  if ! command_present docker-compose; then
-    # shellcheck disable=2016
-    log_warn '`docker-compose` not found! Attempting to install'
-    ./get-docker-compose.sh
-
-    if ! command_present docker-compose; then
-      if [[ "$OSTYPE" == "darwin"* ]]; then
-        error_exit "please install \`docker-compose\` manually" \
-          "Usually, \`docker\` and \`docker-compose\` are bundled together, consider uninstalling your existing docker implementation" \
-          "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
-          "${BOLD}Remember${NORMAL} to start the \`Docker\` app and wait for it to be ${GREEN}${BOLD}READY${NORMAL}."
-      else
-        error_exit "please install \`docker-compose\` manually" \
-          "Usually, \`docker\` and \`docker-compose\` are bundled together, consider uninstalling your existing docker implementation" \
-          "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
-          "${BOLD}Remember${NORMAL} to start the \`docker\` daemon/service and wait for it to be ${GREEN}${BOLD}READY${NORMAL}."
-      fi
-    fi
-  else
-    # shellcheck disable=2016
-    log_step '`docker-compose` found!'
-  fi
-
-  if [[ $DISTRO == *"CentOS"* ]]; then
-    echo 'Starting docker service and making compose accessible by root user'
-    if [ ! -f /usr/bin/docker-compose ]; then
-      sudo ln -s /usr/local/bin/docker-compose  /usr/bin/docker-compose
-    fi
-    sudo systemctl enable docker.service
-    sudo systemctl start docker.service
-  fi
-
-  if retool_containers_present; then
-    log_step 'noticed you have tried Retool before, cleaning up...'
-    $MAYBE_SUDO docker-compose rm -fsv
-  fi
 else
   cd "$DOCKER_CONTEXT" || error_exit "Couldn't \`cd\` into '$DOCKER_CONTEXT'" \
     "if you are having repeat issues, you can \`rm -rf $INSTALL_DIRECTORY\`" \
     "if you're still having issues, you can stop all docker containers using the \`docker\` command"
+fi
+
+if ! command_present docker; then
+  # shellcheck disable=2016
+  log_warn '`docker` not found! Attempting to install. This may take a few minutes.'
+  ./get-docker.sh
+
+  if ! command_present docker; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      error_exit "please install \`docker\` manually" \
+        "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
+        "${BOLD}Remember${NORMAL} to start the \`Docker\` app from the UI."
+    else
+      error_exit "please install \`docker\` manually" \
+        "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
+        "${BOLD}Remember${NORMAL} to start the \`docker\` daemon/service."
+    fi
+  fi
+else
+  # shellcheck disable=2016
+  log_step '`docker` found!'
+fi
+
+if ! command_present docker-compose; then
+  # shellcheck disable=2016
+  log_warn '`docker-compose` not found! Attempting to install'
+  ./get-docker-compose.sh
+
+  if ! command_present docker-compose; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      error_exit "please install \`docker-compose\` manually" \
+        "Usually, \`docker\` and \`docker-compose\` are bundled together, consider uninstalling your existing docker implementation" \
+        "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
+        "${BOLD}Remember${NORMAL} to start the \`Docker\` app and wait for it to be ${GREEN}${BOLD}READY${NORMAL}."
+    else
+      error_exit "please install \`docker-compose\` manually" \
+        "Usually, \`docker\` and \`docker-compose\` are bundled together, consider uninstalling your existing docker implementation" \
+        "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
+        "${BOLD}Remember${NORMAL} to start the \`docker\` daemon/service and wait for it to be ${GREEN}${BOLD}READY${NORMAL}."
+    fi
+  fi
+else
+  # shellcheck disable=2016
+  log_step '`docker-compose` found!'
+fi
+
+if [[ $DISTRO == *"CentOS"* ]]; then
+  echo 'Starting docker service and making compose accessible by root user'
+  if [ ! -f /usr/bin/docker-compose ]; then
+    sudo ln -s /usr/local/bin/docker-compose  /usr/bin/docker-compose
+  fi
+  sudo systemctl enable docker.service
+  sudo systemctl start docker.service
+fi
+
+if retool_containers_present; then
+  log_step 'noticed you have tried Retool before, cleaning up...'
+  $MAYBE_SUDO docker-compose rm -fsv
 fi
 
 if (! $MAYBE_SUDO docker stats --no-stream) && [ "$OSTYPE" == "linux-gnu" ] && [ "$DISTRO" != "*centos*" ]; then

--- a/deploy-retool
+++ b/deploy-retool
@@ -72,7 +72,7 @@ retool_containers_present() {
 
 retool_trial_running() {
   # NB: awk is to remove whitespace from `wc`
-  CONTAINERS="$($MAYBE_SUDO docker-compose ps -q | wc -l | awk '{print $1}')"
+  CONTAINERS="$($MAYBE_SUDO docker compose ps -q | wc -l | awk '{print $1}')"
   test "$CONTAINERS" -gt '0'
 }
 
@@ -82,7 +82,7 @@ DOCKER_CONTEXT="$INSTALL_DIRECTORY/retool-onpremise"
 
 cd "$HOME"
 
-if [ ! -d "$DOCKER_CO$NTEXT" ]; then
+if [ ! -d "$DOCKER_CONTEXT" ]; then
   if [ -d "$INSTALL_DIRECTORY" ]; then
     log_step 'found a partial install, cleaning it up...'
     rm -rf "$INSTALL_DIRECTORY"
@@ -151,41 +151,15 @@ else
   log_step '`docker` found!'
 fi
 
-if ! command_present docker-compose; then
-  # shellcheck disable=2016
-  log_warn '`docker-compose` not found! Attempting to install'
-  ./get-docker-compose.sh
-
-  if ! command_present docker-compose; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-      error_exit "please install \`docker-compose\` manually" \
-        "Usually, \`docker\` and \`docker-compose\` are bundled together, consider uninstalling your existing docker implementation" \
-        "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
-        "${BOLD}Remember${NORMAL} to start the \`Docker\` app and wait for it to be ${GREEN}${BOLD}READY${NORMAL}."
-    else
-      error_exit "please install \`docker-compose\` manually" \
-        "Usually, \`docker\` and \`docker-compose\` are bundled together, consider uninstalling your existing docker implementation" \
-        "Instructions can be found at ${WHITE}${BOLD}https://docs.docker.com/${NORMAL}" \
-        "${BOLD}Remember${NORMAL} to start the \`docker\` daemon/service and wait for it to be ${GREEN}${BOLD}READY${NORMAL}."
-    fi
-  fi
-else
-  # shellcheck disable=2016
-  log_step '`docker-compose` found!'
-fi
-
 if [[ $DISTRO == *"CentOS"* ]]; then
   echo 'Starting docker service and making compose accessible by root user'
-  if [ ! -f /usr/bin/docker-compose ]; then
-    sudo ln -s /usr/local/bin/docker-compose  /usr/bin/docker-compose
-  fi
   sudo systemctl enable docker.service
   sudo systemctl start docker.service
 fi
 
 if retool_containers_present; then
   log_step 'noticed you have tried Retool before, cleaning up...'
-  $MAYBE_SUDO docker-compose rm -fsv
+  $MAYBE_SUDO docker compose rm -fsv
 fi
 
 if (! $MAYBE_SUDO docker stats --no-stream) && [ "$OSTYPE" == "linux-gnu" ] && [ "$DISTRO" != "*centos*" ]; then
@@ -194,7 +168,7 @@ fi
 
 if retool_trial_running; then
   log_step 'stopping Retool for update...'
-  $MAYBE_SUDO docker-compose down
+  $MAYBE_SUDO docker compose down
 fi
 
 if [ ! -f ./docker-compose-ssl.yml ]; then
@@ -205,11 +179,11 @@ if [ -f ./docker-compose-local-trial.yml ]; then
 fi
 
 log_step 'updating Retool!'
-$MAYBE_SUDO docker-compose pull
+$MAYBE_SUDO docker compose pull
 
 log_step "running Retool! ${WHITE}${BOLD}This can take up to 5 minutes${NORMAL}"
 
-$MAYBE_SUDO docker-compose up -d
+$MAYBE_SUDO docker compose up -d
 
 echo ""
 echo " -- ${GREEN}${BOLD}!! RETOOL IS BOOTING !!${NORMAL} --"
@@ -220,7 +194,7 @@ echo " -- ${GREEN}${BOLD}!! RETOOL IS BOOTING !!${NORMAL} --"
 WAITED=0
 API_CONTAINER_ID=""
 api_container_up() {
-  API_DOCKER_CONTAINER_UP=$($MAYBE_SUDO docker-compose ps --filter "status=running" | grep 'retool.*api'| wc -l | awk '{print $1}')
+  API_DOCKER_CONTAINER_UP=$($MAYBE_SUDO docker compose ps --filter "status=running" | grep 'retool.*api'| wc -l | awk '{print $1}')
   test "$API_DOCKER_CONTAINER_UP" -gt '0'
 }
 
@@ -236,7 +210,7 @@ while [ $WAITED -lt 20 ] && api_container_up; do
 done
 
 if ! api_container_up; then
-  $MAYBE_SUDO docker-compose up -d > /dev/null 2>&1
+  $MAYBE_SUDO docker compose up -d > /dev/null 2>&1
   WAITED=0
   while [ $WAITED -lt 10 ] && ! api_container_up; do
     WAITED=$((WAITED + 1))
@@ -248,7 +222,7 @@ fi
 WAITED=0
 while [ $WAITED -lt 20 ]; do
     if ! api_container_up; then
-        $MAYBE_SUDO docker-compose up -d > /dev/null 2>&1
+        $MAYBE_SUDO docker compose up -d > /dev/null 2>&1
     fi
     WAITED=$((WAITED + 1))
     sleep 1
@@ -258,7 +232,7 @@ if ! api_container_up; then
   echo "ERROR: Failed starting the Retool api container"
   exit 1
 else
-  API_CONTAINER_ID=$( $MAYBE_SUDO docker inspect --format="{{.Id}}" $(docker-compose ps | grep 'retool.*api' | cut -d ' ' -f 1)
+  API_CONTAINER_ID=$( $MAYBE_SUDO docker inspect --format="{{.Id}}" $(docker compose ps | grep 'retool.*api' | cut -d ' ' -f 1)
 )
 fi
 

--- a/deploy-retool
+++ b/deploy-retool
@@ -114,6 +114,7 @@ if [ ! -d "$DOCKER_CONTEXT" ]; then
 
   # NB: this is to make onprem containers to all get named the same.
   cd retool-onpremise
+  git switch fix-ssop-start-up
   if ! command_present unzip; then
     git checkout ssop # TODO(hirday): delete this.
   fi

--- a/deploy-retool
+++ b/deploy-retool
@@ -233,7 +233,7 @@ if ! api_container_up; then
   echo "ERROR: Failed starting the Retool api container"
   exit 1
 else
-  API_CONTAINER_ID=$( $MAYBE_SUDO docker inspect --format="{{.Id}}" $(docker compose ps | grep 'retool.*api' | cut -d ' ' -f 1)
+  API_CONTAINER_ID=$( $MAYBE_SUDO docker inspect --format="{{.Id}}" $($MAYBE_SUDO docker compose ps | grep 'retool.*api' | cut -d ' ' -f 1)
 )
 fi
 

--- a/deploy-retool
+++ b/deploy-retool
@@ -255,7 +255,7 @@ if ! api_container_up; then
   echo "ERROR: Failed starting the Retool api container"
   exit 1
 else
-  API_CONTAINER_ID=$( $MAYBE_SUDO docker inspect --format="{{.Id}}" $(docker-compose ps | grep 'api' | cut -d ' ' -f 1)
+  API_CONTAINER_ID=$( $MAYBE_SUDO docker inspect --format="{{.Id}}" $(docker-compose ps | grep 'retool.*api' | cut -d ' ' -f 1)
 )
 fi
 

--- a/deploy-retool
+++ b/deploy-retool
@@ -207,7 +207,9 @@ log_step 'updating Retool!'
 $MAYBE_SUDO docker-compose pull
 
 log_step "running Retool! ${WHITE}${BOLD}This can take up to 5 minutes${NORMAL}"
+
 $MAYBE_SUDO docker-compose up -d
+
 echo ""
 echo " -- ${GREEN}${BOLD}!! RETOOL IS BOOTING !!${NORMAL} --"
 

--- a/deploy-retool
+++ b/deploy-retool
@@ -66,7 +66,7 @@ command_present() {
 
 retool_containers_present() {
   # NB: awk is to remove whitespace from `wc`
-  RETOOL_IMAGES="$($MAYBE_SUDO docker image ls | grep 'retool-onpremise' | wc -l | awk '{print $1}')"
+  RETOOL_IMAGES="$($MAYBE_SUDO docker image ls | grep 'retool.*onpremise' | wc -l | awk '{print $1}')"
   test "$RETOOL_IMAGES" -gt '0'
 }
 
@@ -207,9 +207,7 @@ log_step 'updating Retool!'
 $MAYBE_SUDO docker-compose pull
 
 log_step "running Retool! ${WHITE}${BOLD}This can take up to 5 minutes${NORMAL}"
-
 $MAYBE_SUDO docker-compose up -d
-
 echo ""
 echo " -- ${GREEN}${BOLD}!! RETOOL IS BOOTING !!${NORMAL} --"
 
@@ -219,8 +217,8 @@ echo " -- ${GREEN}${BOLD}!! RETOOL IS BOOTING !!${NORMAL} --"
 WAITED=0
 API_CONTAINER_ID=""
 api_container_up() {
-  API_DOCKER_CONTAINER="$($MAYBE_SUDO docker ps | grep 'retool-onpremise[-_]api')"
-  test -n "$API_DOCKER_CONTAINER"
+  API_DOCKER_CONTAINER_UP=$($MAYBE_SUDO docker-compose ps --filter "status=running" | grep 'retool.*api'| wc -l | awk '{print $1}')
+  test "$API_DOCKER_CONTAINER_UP" -gt '0'
 }
 
 api_running() {
@@ -257,7 +255,8 @@ if ! api_container_up; then
   echo "ERROR: Failed starting the Retool api container"
   exit 1
 else
-  API_CONTAINER_ID=$($MAYBE_SUDO docker ps -a | grep -i retool-onpremise[-_]api | awk '{print $1}')
+  API_CONTAINER_ID=$( $MAYBE_SUDO docker inspect --format="{{.Id}}" $(docker-compose ps | grep 'api' | cut -d ' ' -f 1)
+)
 fi
 
 WAITED=0
@@ -271,7 +270,6 @@ while [ $WAITED -lt 40 ] && ! api_running; do
     sleep 3
 done
 
-echo
 if ! api_running; then
   echo "There was an issue starting the Retool container"
   echo "You can view the logs by running: docker logs $API_CONTAINER_ID')"

--- a/deploy-retool
+++ b/deploy-retool
@@ -114,7 +114,6 @@ if [ ! -d "$DOCKER_CONTEXT" ]; then
 
   # NB: this is to make onprem containers to all get named the same.
   cd retool-onpremise
-  git switch fix-ssop-start-up
   if ! command_present unzip; then
     git checkout ssop # TODO(hirday): delete this.
   fi

--- a/get-docker-compose.sh
+++ b/get-docker-compose.sh
@@ -1,2 +1,0 @@
-sudo -E curl -L https://github.com/docker/compose/releases/download/2.6.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose

--- a/get-docker-compose.sh
+++ b/get-docker-compose.sh
@@ -1,2 +1,2 @@
-sudo -E curl -L https://github.com/docker/compose/releases/download/1.17.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+sudo -E curl -L https://github.com/docker/compose/releases/download/2.6.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,2 @@
 ./get-docker.sh
-./get-docker-compose.sh
 ./docker_setup


### PR DESCRIPTION
fix ssop start up script that is currently failing sometimes because different version of docker-compose are generating different names for our containers and some of our grep calls are not inclusive enough