### PR TITLE
Update ECS + Fargate jobs-runner resource specs

### DIFF
--- a/cloudformation/fargate.private.yaml
+++ b/cloudformation/fargate.private.yaml
@@ -130,8 +130,8 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       NetworkMode: awsvpc
-      Cpu: '1024'
-      Memory: '2048'
+      Cpu: '2048'
+      Memory: '4096'
       Family: 'retool'
       TaskRoleArn: !Ref 'RetoolTaskRole'
       ExecutionRoleArn: !Ref 'RetoolExecutionRole'

--- a/cloudformation/fargate.yaml
+++ b/cloudformation/fargate.yaml
@@ -127,8 +127,8 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       NetworkMode: awsvpc
-      Cpu: '1024'
-      Memory: '2048'
+      Cpu: '2048'
+      Memory: '4096'
       Family: 'retool'
       TaskRoleArn: !Ref 'RetoolTaskRole'
       ExecutionRoleArn: !Ref 'RetoolExecutionRole'

--- a/cloudformation/retool.yaml
+++ b/cloudformation/retool.yaml
@@ -125,10 +125,10 @@ Resources:
       TaskRoleArn: !Ref 'RetoolTaskRole'
       ContainerDefinitions:
       - Name: 'retool-jobs-runner'
-        Cpu: '1024'
+        Cpu: '2048'
+        Memory: '4096'
         Essential: 'true'
         Image: !Ref 'Image'
-        Memory: '2048'
         LogConfiguration:
           LogDriver: awslogs
           Options:


### PR DESCRIPTION
Update the CloudFormation templates for ECS + Fargate to set the resource limit for the jobs-runner task to 2 vCPU + 4 GB mem