### PR TITLE
Update recommended EC2 instance type

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Spin up a new EC2 instance. If using AWS, use the following steps:
 
 1. Click **Launch Instance** from the EC2 dashboard.
 1. Click **Select** for an instance of Ubuntu `16.04` or higher.
-1. Select an instance type of at least `t3.medium` and click **Next**.
+1. Select an instance type of at least `t3.large` and click **Next**.
 1. Ensure you select the VPC that also includes the databases / API’s you will want to connect to and click **Next**.
 1. Increase the storage size to `60` GB or higher and click **Next**.
 1. Optionally add some Tags (e.g. `app = retool`) and click **Next**. This makes it easier to find if you have a lot of instances.


### PR DESCRIPTION
We recommend 8GB of memory for VM deployments. Currently, the EC2 deploy instructions recommend a t3.medium instance which is only 4GB of memory.

This PR updates the EC2 deploy instructions to recommend a t3.large instance.

![image](https://user-images.githubusercontent.com/4918572/226451781-f0463dec-9e7e-4091-a1c4-ae81cc5710af.png)