### PR TITLE
Fixed undelimited character

### DIFF
--- a/local-trial
+++ b/local-trial
@@ -209,7 +209,7 @@ echo ""
 echo " -- ${GREEN}${BOLD}!! RETOOL IS BOOTING !!${NORMAL} --"
 
 
-# NB: the API doesn't start up the first time, this is why the below is complex
+# NB: the API does not start up the first time, this is why the below is complex
 
 WAITED=0
 


### PR DESCRIPTION
We have an apostrophe that (may) be preventing users from deploying using our one-click deploy. Fixed based on this issue here: https://github.com/tryretool/retool-onpremise/issues/155