### PR TITLE
Updated docker-compose-workflows.yml to support Retool DB. 

### DIFF
--- a/docker-compose-workflows.yml
+++ b/docker-compose-workflows.yml
@@ -131,16 +131,15 @@ services:
     volumes:
       - data:/var/lib/postgresql/data
 
-  # Postgres for storing application data
-  user-postgres:
-    image: 'postgres:11.13'
-    env_file: ./user_data/user_data.env
+  # Postgres for Retool Database
+  retooldb-postgres:
+    image: "postgres:14.3"
+    env_file: retooldb.env
     networks:
-      - frontend-network
       - backend-network
       - db-connector-network
     volumes:
-      - user-data:/var/lib/postgresql/data
+      - retooldb-data:/var/lib/postgresql/data
 
   # Not required, but leave this container to use nginx for handling the frontend & SSL certification
   https-portal:
@@ -211,4 +210,4 @@ networks:
 volumes:
   ssh:
   data:
-  user-data:
+  retooldb-data:


### PR DESCRIPTION
Also - Removed user-postgres

This change would make docker-compose-workflows.yml consistent with docker-compose.yml, and enable a full deployment of Retool (including Retool DB) when following the instructions to deploy Workflows.