### PR TITLE
Simplify Kubernetes secret template

### DIFF
--- a/kubernetes/retool-secrets.template.yaml
+++ b/kubernetes/retool-secrets.template.yaml
@@ -4,9 +4,9 @@ metadata:
   name: retoolsecrets
 type: Opaque
 data:
-  jwt_secret: {{ random base64 encoded string to sign jwt tokens }}
-  encryption_key: {{ random base64 encoded string to encrypt database credentials }}
-  postgres_password: {{ random base64 encoded string to set as the internal retool db password }}
-  license_key: {{ base64 encoded string of the license key Retool will provide you }}
-  google_client_id: {{ google client id encoded in base64 }}
-  google_client_secret: {{ google client secret encoded in base64 }}
+  jwt_secret: ""
+  encryption_key: ""
+  postgres_password: ""
+  license_key: ""
+  google_client_id: ""
+  google_client_secret: ""


### PR DESCRIPTION
Replace the double curlies with empty quotes in the k8s secrets template. The double curlies are misleading. Descriptions contained within the double curlies have been moved to the docs.