### PR TITLE
Workflows deployment for ECS on EC2 v0

### DIFF
--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -17,7 +17,10 @@ Parameters:
     Description: Image to use in the service.
   DesiredCount:
     Type: Number
-    Description: Default number of tasks to run
+    Description: Default number of tasks to run for Retool api container
+  DesiredWorkflowsCount:
+    Type: Number
+    Description: Default number of tasks to run for Retool Workflows containers
   MaximumPercent:
     Type: Number
     Description: Maximum percentage of tasks to run during a deployment
@@ -475,7 +478,7 @@ Resources:
           SecurityGroups: [!Ref 'RetoolSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
-      DesiredCount: !Ref 'DesiredCount'
+      DesiredCount: !Ref 'DesiredWorkflowsCount'
       DeploymentConfiguration:
         MaximumPercent: !Ref 'MaximumPercent'
         MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
@@ -493,7 +496,7 @@ Resources:
       ServiceRegistries:
         - RegistryArn: !GetAtt [RetoolWorkflowBackendServiceCloudmapService, Arn]
       Cluster: !Ref 'Cluster'
-      DesiredCount: !Ref 'DesiredCount'
+      DesiredCount: !Ref 'DesiredWorkflowsCount'
       DeploymentConfiguration:
         MaximumPercent: !Ref 'MaximumPercent'
         MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
@@ -888,7 +891,7 @@ Resources:
       ServiceRegistries:
         - RegistryArn: !GetAtt [TemporalFrontendCloudmapService, Arn]
       Cluster: !Ref 'Cluster'
-      DesiredCount: !Ref 'DesiredCount'
+      DesiredCount: !Ref 'DesiredWorkflowsCount'
       DeploymentConfiguration:
         MaximumPercent: !Ref 'MaximumPercent'
         MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
@@ -903,7 +906,7 @@ Resources:
           SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
-      DesiredCount: !Ref 'DesiredCount'
+      DesiredCount: !Ref 'DesiredWorkflowsCount'
       DeploymentConfiguration:
         MaximumPercent: !Ref 'MaximumPercent'
         MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
@@ -918,7 +921,7 @@ Resources:
           SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
-      DesiredCount: !Ref 'DesiredCount'
+      DesiredCount: !Ref 'DesiredWorkflowsCount'
       DeploymentConfiguration:
         MaximumPercent: !Ref 'MaximumPercent'
         MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
@@ -933,7 +936,7 @@ Resources:
           SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
-      DesiredCount: !Ref 'DesiredCount'
+      DesiredCount: 1
       DeploymentConfiguration:
         MaximumPercent: !Ref 'MaximumPercent'
         MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
@@ -948,7 +951,7 @@ Resources:
           SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
-      DesiredCount: !Ref 'DesiredCount'
+      DesiredCount: 1
       DeploymentConfiguration:
         MaximumPercent: !Ref 'MaximumPercent'
         MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'

--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -50,15 +50,28 @@ Resources:
       ToPort: '80'
       CidrIp: '0.0.0.0/0'
   
-  InternalHttpInbound:
+  RetoolSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'retool container security group']]
+      VpcId: !Ref 'VpcId'
+
+  ALBInbound:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'ALBSecurityGroup'
+      GroupId: !Ref 'RetoolSecurityGroup'
       IpProtocol: tcp
       FromPort: '3000'
       ToPort: '3000'
-      CidrIp: '0.0.0.0/0'
-    
+      SourceSecurityGroupId: !Ref 'ALBSecurityGroup'
+
+  RetoolSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref 'RetoolSecurityGroup'
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref 'RetoolSecurityGroup'
+
   TemporalSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -406,7 +419,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: ECSALB
     Properties:
-      TargetType: instance # needed for EC2 with bridge networkmode
+      TargetType: ip
       HealthCheckIntervalSeconds: 61
       HealthCheckPath: '/api/checkHealth'
       HealthCheckProtocol: HTTP

--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -255,6 +255,8 @@ Resources:
           # Remove below when serving Retool over https
           - Name: COOKIE_INSECURE
             Value: "true"
+        PortMappings:
+        - ContainerPort: '3000'
         Command: ["./docker_scripts/start_api.sh"]
 
   RetoolWorkflowsWorkerTask:
@@ -838,7 +840,7 @@ Resources:
     Properties:
       ServiceRegistries:
         - RegistryArn: !GetAtt [TemporalFrontendCloudmapService, Arn]
-          ContainerName: "retool-temporal-frontend"
+          ContainerName: "temporal-cluster-frontend"
           ContainerPort: 7233
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'

--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -5,7 +5,10 @@ Parameters:
     Description: Environment string sent back to plogger with the logs
   SubnetId:
     Type: List<AWS::EC2::Subnet::Id>
-    Description: Select at two subnets in your selected VPC.
+    Description: Select at two private subnets in your selected VPC.
+  PublicSubnetId:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Select at least one public subnet in your selected VPC, for your Application Load Balancer.
   Cluster:
     Type: String
     Description: Cluster to put service in.
@@ -372,7 +375,7 @@ Resources:
       LoadBalancerAttributes:
       - Key: idle_timeout.timeout_seconds
         Value: '60'
-      Subnets: !Ref 'SubnetId'
+      Subnets: !Ref 'PublicSubnetId'
       SecurityGroups: [!Ref 'ALBSecurityGroup']
 
   ALBListener:
@@ -867,7 +870,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       ServiceRegistries:
         - RegistryArn: !GetAtt [TemporalFrontendCloudmapService, Arn]
@@ -884,7 +887,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
@@ -899,7 +902,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
@@ -914,7 +917,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
@@ -929,7 +932,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'TemporalSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'

--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -511,7 +511,7 @@ Resources:
       DnsConfig:
         DnsRecords:
           - TTL: 60
-            Type: A
+            Type: SRV
         NamespaceId: !GetAtt [WorkflowsCloudMapNamespace, Id]
         RoutingPolicy: MULTIVALUE
       HealthCheckCustomConfig:
@@ -894,7 +894,7 @@ Resources:
       DnsConfig:
         DnsRecords:
           - TTL: 60
-            Type: A
+            Type: SRV
         NamespaceId: !GetAtt [WorkflowsCloudMapNamespace, Id]
         RoutingPolicy: MULTIVALUE
       HealthCheckCustomConfig:

--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -109,6 +109,7 @@ Resources:
     Properties:
       Family: 'retool'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
       - Name: 'retool'
         Cpu: '2048'
@@ -165,6 +166,7 @@ Resources:
     Properties:
       Family: 'retool-jobs-runner'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
       - Name: 'retool-jobs-runner'
         Cpu: '1024'
@@ -209,6 +211,7 @@ Resources:
     Properties:
       Family: 'retool-workflows-backend'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
       - Name: 'retool-workflows-backend'
         Cpu: '2048'
@@ -264,6 +267,7 @@ Resources:
     Properties:
       Family: 'retool-workflows-worker'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
       - Name: 'retool-workflows-worker'
         Cpu: '2048'
@@ -418,6 +422,11 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: ALBListener
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
       DeploymentConfiguration:
@@ -428,11 +437,15 @@ Resources:
         ContainerPort: '3000'
         TargetGroupArn: !Ref 'ECSTG'
       TaskDefinition: !Ref 'RetoolTask'
-      Role: !Ref 'RetoolServiceRole'
 
   RetoolJobsRunnerECSservice:
     Type: AWS::ECS::Service
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: 1
       TaskDefinition: !Ref 'RetoolJobsRunnerTask'
@@ -440,6 +453,11 @@ Resources:
   RetoolWorkflowsWorkerECSService:
     Type: AWS::ECS::Service
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
       DeploymentConfiguration:
@@ -451,10 +469,13 @@ Resources:
     DependsOn: RetoolWorkflowBackendServiceCloudmapService
     Type: AWS::ECS::Service
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       ServiceRegistries:
         - RegistryArn: !GetAtt [RetoolWorkflowBackendServiceCloudmapService, Arn]
-          ContainerName: "retool-workflows-backend"
-          ContainerPort: 3000
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
       DeploymentConfiguration:
@@ -511,7 +532,7 @@ Resources:
       DnsConfig:
         DnsRecords:
           - TTL: 60
-            Type: SRV
+            Type: A
         NamespaceId: !GetAtt [WorkflowsCloudMapNamespace, Id]
         RoutingPolicy: MULTIVALUE
       HealthCheckCustomConfig:
@@ -583,6 +604,7 @@ Resources:
     Properties:
       Family: 'retool-temporal-frontend'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: temporal-cluster-frontend
           Cpu: '256'
@@ -640,6 +662,7 @@ Resources:
     Properties:
       Family: 'retool-temporal-history'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: temporal-cluster-history
           Cpu: '512'
@@ -699,6 +722,7 @@ Resources:
     Properties:
       Family: 'retool-temporal-matching'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: temporal-cluster-matching
           Cpu: '512'
@@ -758,6 +782,7 @@ Resources:
     Properties:
       Family: 'retool-temporal-worker'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: temporal-cluster-worker
           Cpu: '256'
@@ -817,6 +842,7 @@ Resources:
     Properties:
       Family: 'retool-temporal-web'
       TaskRoleArn: !Ref 'RetoolTaskRole'
+      NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: temporal-cluster-web
           Cpu: '256'
@@ -838,10 +864,13 @@ Resources:
   TemporalFrontendService:
     Type: AWS::ECS::Service
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       ServiceRegistries:
         - RegistryArn: !GetAtt [TemporalFrontendCloudmapService, Arn]
-          ContainerName: "temporal-cluster-frontend"
-          ContainerPort: 7233
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
       DeploymentConfiguration:
@@ -852,6 +881,11 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: TemporalFrontendService
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
       DeploymentConfiguration:
@@ -862,6 +896,11 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: TemporalFrontendService
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
       DeploymentConfiguration:
@@ -872,6 +911,11 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: TemporalFrontendService
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
       DeploymentConfiguration:
@@ -882,6 +926,11 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: TemporalFrontendService
     Properties:
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
+          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
       DeploymentConfiguration:
@@ -894,7 +943,7 @@ Resources:
       DnsConfig:
         DnsRecords:
           - TTL: 60
-            Type: SRV
+            Type: A
         NamespaceId: !GetAtt [WorkflowsCloudMapNamespace, Id]
         RoutingPolicy: MULTIVALUE
       HealthCheckCustomConfig:

--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -6,9 +6,9 @@ Parameters:
   SubnetId:
     Type: List<AWS::EC2::Subnet::Id>
     Description: Select at two private subnets in your selected VPC.
-  PublicSubnetId:
+  ALBSubnetId:
     Type: List<AWS::EC2::Subnet::Id>
-    Description: Select at least one public subnet in your selected VPC, for your Application Load Balancer.
+    Description: Select the subnets for your Application Load Balancer.
   Cluster:
     Type: String
     Description: Cluster to put service in.
@@ -89,7 +89,7 @@ Resources:
       IpProtocol: tcp
       FromPort: 7233
       ToPort: 7233
-      SourceSecurityGroupId: !Ref 'ALBSecurityGroup'
+      SourceSecurityGroupId: !Ref 'RetoolSecurityGroup'
 
   TemporalSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -388,7 +388,7 @@ Resources:
       LoadBalancerAttributes:
       - Key: idle_timeout.timeout_seconds
         Value: '60'
-      Subnets: !Ref 'PublicSubnetId'
+      Subnets: !Ref 'ALBSubnetId'
       SecurityGroups: [!Ref 'ALBSecurityGroup']
 
   ALBListener:
@@ -441,7 +441,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'RetoolSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
@@ -460,7 +460,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'RetoolSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: 1
@@ -472,7 +472,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'RetoolSecurityGroup']
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
@@ -488,7 +488,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'ALBSecurityGroup']
+          SecurityGroups: [!Ref 'RetoolSecurityGroup']
           Subnets: !Ref 'SubnetId'
       ServiceRegistries:
         - RegistryArn: !GetAtt [RetoolWorkflowBackendServiceCloudmapService, Arn]

--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -1,0 +1,906 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  Environment:
+    Type: String
+    Description: Environment string sent back to plogger with the logs
+  SubnetId:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Select at two subnets in your selected VPC.
+  Cluster:
+    Type: String
+    Description: Cluster to put service in.
+  Image:
+    Type: String
+    Description: Image to use in the service.
+  DesiredCount:
+    Type: Number
+    Description: Default number of tasks to run
+  MaximumPercent:
+    Type: Number
+    Description: Maximum percentage of tasks to run during a deployment
+    Default: 150
+  MinimumHealthyPercent:
+    Type: Number
+    Default: 50
+    Description: Maximum percentage of tasks to run during a deployment
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: Select a VPC that allows instances access to the Internet.
+  Force:
+    Type: String
+    Description: "Used to force the deployment even when the image and parameters are otherwised unchanged."
+    Default: "false"
+
+Resources:
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'load balancer security group']]
+      VpcId: !Ref 'VpcId'
+
+  GlobalHttpInbound:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref 'ALBSecurityGroup'
+      IpProtocol: tcp
+      FromPort: '80'
+      ToPort: '80'
+      CidrIp: '0.0.0.0/0'
+  
+  InternalHttpInbound:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref 'ALBSecurityGroup'
+      IpProtocol: tcp
+      FromPort: '3000'
+      ToPort: '3000'
+      CidrIp: '0.0.0.0/0'
+    
+  TemporalSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'temporal security group']]
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: "-1"
+      VpcId: !Ref 'VpcId'
+
+  TemporalFrontendIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref 'TemporalSecurityGroup'
+      IpProtocol: tcp
+      FromPort: 7233
+      ToPort: 7233
+      SourceSecurityGroupId: !Ref 'ALBSecurityGroup'
+
+  TemporalSelfIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref 'TemporalSecurityGroup'
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref 'TemporalSecurityGroup'
+
+
+  CloudwatchLogsGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['-', [ECSLogGroup, !Ref 'AWS::StackName']]
+      RetentionInDays: 14
+
+  RDSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'database security group']]
+      VpcId: !Ref 'VpcId'
+
+  RetoolECSPostgresInbound:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt [RDSSecurityGroup, GroupId]
+      IpProtocol: tcp
+      FromPort: '5432'
+      ToPort: '5432'
+      CidrIp: '0.0.0.0/0'
+
+  RetoolTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+      - Name: 'retool'
+        Cpu: '2048'
+        Memory: '4096'
+        Essential: 'true'
+        Image: !Ref 'Image'
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref 'CloudwatchLogsGroup'
+            awslogs-region: !Ref 'AWS::Region'
+            awslogs-stream-prefix: "SERVICE_RETOOL"
+        Environment:
+          - Name: NODE_ENV
+            Value: production
+          - Name: SERVICE_TYPE
+            Value: MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
+          - Name: "FORCE_DEPLOYMENT"
+            Value: !Ref "Force"
+          - Name: POSTGRES_DB
+            Value: hammerhead_production
+          - Name: POSTGRES_HOST
+            Value: !GetAtt [RetoolRDSInstance, Endpoint.Address]
+          - Name: POSTGRES_SSL_ENABLED
+            Value: "true"
+          - Name: POSTGRES_PORT
+            Value: "5432"
+          - Name: POSTGRES_USER
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
+          - Name: POSTGRES_PASSWORD
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
+          - Name: JWT_SECRET
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolJWTSecret, ':SecretString:password}}' ]]
+          - Name: ENCRYPTION_KEY
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
+            Value: temporal.retoolsvc
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
+            Value: "7233"
+          - Name: WORKFLOW_BACKEND_HOST
+            Value: http://workflows-backend.retoolsvc:3000
+          - Name: LICENSE_KEY
+            Value: "EXPIRED-LICENSE-KEY-TRIAL"
+          # Remove below when serving Retool over https
+          - Name: COOKIE_INSECURE
+            Value: "true"
+        PortMappings:
+        - ContainerPort: '3000'
+          # HostPort: '80'
+        Command: ["./docker_scripts/start_api.sh"]
+
+  RetoolJobsRunnerTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool-jobs-runner'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+      - Name: 'retool-jobs-runner'
+        Cpu: '1024'
+        Memory: '2048'
+        Essential: 'true'
+        Image: !Ref 'Image'
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref 'CloudwatchLogsGroup'
+            awslogs-region: !Ref 'AWS::Region'
+            awslogs-stream-prefix: "SERVICE_RETOOL"
+        Environment:
+          - Name: NODE_ENV
+            Value: production
+          - Name: SERVICE_TYPE
+            Value: JOBS_RUNNER
+          - Name: "FORCE_DEPLOYMENT"
+            Value: !Ref "Force"
+          - Name: POSTGRES_DB
+            Value: hammerhead_production
+          - Name: POSTGRES_HOST
+            Value: !GetAtt [RetoolRDSInstance, Endpoint.Address]
+          - Name: POSTGRES_SSL_ENABLED
+            Value: "true"
+          - Name: POSTGRES_PORT
+            Value: "5432"
+          - Name: POSTGRES_USER
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
+          - Name: POSTGRES_PASSWORD
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
+          - Name: JWT_SECRET
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolJWTSecret, ':SecretString:password}}' ]]
+          - Name: ENCRYPTION_KEY
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
+          - Name: LICENSE_KEY
+            Value: "EXPIRED-LICENSE-KEY-TRIAL"
+        Command: ["./docker_scripts/start_api.sh"]
+
+  RetoolWorkkflowsBackendTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool-workflows-backend'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+      - Name: 'retool-workflows-backend'
+        Cpu: '2048'
+        Memory: '4096'
+        Essential: 'true'
+        Image: !Ref 'Image'
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref 'CloudwatchLogsGroup'
+            awslogs-region: !Ref 'AWS::Region'
+            awslogs-stream-prefix: "SERVICE_RETOOL"
+        Environment:
+          - Name: NODE_ENV
+            Value: production
+          - Name: SERVICE_TYPE
+            Value: WORKFLOW_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
+          - Name: "FORCE_DEPLOYMENT"
+            Value: !Ref "Force"
+          - Name: POSTGRES_DB
+            Value: hammerhead_production
+          - Name: POSTGRES_HOST
+            Value: !GetAtt [RetoolRDSInstance, Endpoint.Address]
+          - Name: POSTGRES_SSL_ENABLED
+            Value: "true"
+          - Name: POSTGRES_PORT
+            Value: "5432"
+          - Name: POSTGRES_USER
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
+          - Name: POSTGRES_PASSWORD
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
+          - Name: JWT_SECRET
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolJWTSecret, ':SecretString:password}}' ]]
+          - Name: ENCRYPTION_KEY
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
+            Value: temporal.retoolsvc
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
+            Value: "7233"
+          - Name: WORKFLOW_BACKEND_HOST
+            Value: http://workflows-backend.retoolsvc:3000
+          - Name: LICENSE_KEY
+            Value: "EXPIRED-LICENSE-KEY-TRIAL"
+          # Remove below when serving Retool over https
+          - Name: COOKIE_INSECURE
+            Value: "true"
+        Command: ["./docker_scripts/start_api.sh"]
+
+  RetoolWorkflowsWorkerTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool-workflows-worker'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+      - Name: 'retool-workflows-worker'
+        Cpu: '2048'
+        Memory: '4096'
+        Essential: 'true'
+        Image: !Ref 'Image'
+        LogConfiguration:
+          LogDriver: awslogs
+          Options:
+            awslogs-group: !Ref 'CloudwatchLogsGroup'
+            awslogs-region: !Ref 'AWS::Region'
+            awslogs-stream-prefix: "SERVICE_RETOOL"
+        Environment:
+          - Name: NODE_ENV
+            Value: production
+          - Name: SERVICE_TYPE
+            Value: WORKFLOW_TEMPORAL_WORKER
+          - Name: "FORCE_DEPLOYMENT"
+            Value: !Ref "Force"
+          - Name: POSTGRES_DB
+            Value: hammerhead_production
+          - Name: POSTGRES_HOST
+            Value: !GetAtt [RetoolRDSInstance, Endpoint.Address]
+          - Name: POSTGRES_SSL_ENABLED
+            Value: "true"
+          - Name: POSTGRES_PORT
+            Value: "5432"
+          - Name: POSTGRES_USER
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
+          - Name: POSTGRES_PASSWORD
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
+          - Name: JWT_SECRET
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolJWTSecret, ':SecretString:password}}' ]]
+          - Name: ENCRYPTION_KEY
+            Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
+            Value: temporal.retoolsvc
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
+            Value: "7233"
+          - Name: WORKFLOW_BACKEND_HOST
+            Value: http://workflows-backend.retoolsvc:3000
+          - Name: LICENSE_KEY
+            Value: "EXPIRED-LICENSE-KEY-TRIAL"
+        Command: ["./docker_scripts/start_api.sh"]
+
+  RetoolJWTSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'This is the secret for Retool JWTs'
+      GenerateSecretString:
+        SecretStringTemplate: '{}'
+        GenerateStringKey: 'password'
+        PasswordLength: 16
+        ExcludeCharacters: '"@/\'
+
+  RetoolEncryptionKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'This is the secret for encrypting credentials'
+      GenerateSecretString:
+        SecretStringTemplate: '{}'
+        GenerateStringKey: 'password'
+        PasswordLength: 16
+        ExcludeCharacters: '"@/\'
+
+  RetoolRDSSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'This is the secret for the Retool RDS instance'
+      GenerateSecretString:
+        SecretStringTemplate: '{"username": "retool"}'
+        GenerateStringKey: 'password'
+        PasswordLength: 16
+        ExcludeCharacters: '"@/\'
+
+
+  RetoolRDSInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      AllocatedStorage: "80"
+      DBInstanceClass: "db.m4.large"
+      Engine: postgres
+      EngineVersion: "11.12"
+      DBName: "hammerhead_production"
+      MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:username}}' ]]
+      MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolRDSSecret, ':SecretString:password}}' ]]
+      Port: "5432"
+      VPCSecurityGroups: [!GetAtt [RDSSecurityGroup, GroupId]]
+      DBSubnetGroupName: !Ref 'RDSSubnetGroup'
+
+  RDSSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties: 
+      DBSubnetGroupDescription: !Join [" ", [!Ref 'AWS::StackName', 'rds subnet security group']]
+      SubnetIds: !Ref 'SubnetId' 
+
+  ECSALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Join ['-', [!Ref 'AWS::StackName', 'lb']]
+      Scheme: "internet-facing"
+      LoadBalancerAttributes:
+      - Key: idle_timeout.timeout_seconds
+        Value: '60'
+      Subnets: !Ref 'SubnetId'
+      SecurityGroups: [!Ref 'ALBSecurityGroup']
+
+  ALBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn: RetoolServiceRole
+    Properties:
+      DefaultActions:
+      - Type: forward
+        TargetGroupArn: !Ref 'ECSTG'
+      LoadBalancerArn: !Ref 'ECSALB'
+      Port: '80'
+      Protocol: HTTP
+
+  ECSALBListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    DependsOn: ALBListener
+    Properties:
+      Actions:
+      - Type: forward
+        TargetGroupArn: !Ref 'ECSTG'
+      Conditions:
+      - Field: path-pattern
+        Values: [/]
+      ListenerArn: !Ref 'ALBListener'
+      Priority: 1
+
+  ECSTG:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    DependsOn: ECSALB
+    Properties:
+      TargetType: instance # needed for EC2 with bridge networkmode
+      HealthCheckIntervalSeconds: 61
+      HealthCheckPath: '/api/checkHealth'
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 60
+      HealthyThresholdCount: 4
+      Name: !Join ['-', [!Ref 'AWS::StackName', 'tg']]
+      Port: '3000'
+      Protocol: HTTP
+      UnhealthyThresholdCount: 2
+      VpcId: !Ref 'VpcId'
+      TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: '30'
+
+  RetoolECSservice:
+    Type: AWS::ECS::Service
+    DependsOn: ALBListener
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: !Ref 'DesiredCount'
+      DeploymentConfiguration:
+        MaximumPercent: !Ref 'MaximumPercent'
+        MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
+      LoadBalancers:
+      - ContainerName: 'retool'
+        ContainerPort: '3000'
+        TargetGroupArn: !Ref 'ECSTG'
+      TaskDefinition: !Ref 'RetoolTask'
+      Role: !Ref 'RetoolServiceRole'
+
+  RetoolJobsRunnerECSservice:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: 1
+      TaskDefinition: !Ref 'RetoolJobsRunnerTask'
+
+  RetoolWorkflowsWorkerECSService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: !Ref 'DesiredCount'
+      DeploymentConfiguration:
+        MaximumPercent: !Ref 'MaximumPercent'
+        MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
+      TaskDefinition: !Ref 'RetoolWorkflowsWorkerTask'
+
+  RetoolWorkkflowsBackendECSService:
+    DependsOn: RetoolWorkflowBackendServiceCloudmapService
+    Type: AWS::ECS::Service
+    Properties:
+      ServiceRegistries:
+        - RegistryArn: !GetAtt [RetoolWorkflowBackendServiceCloudmapService, Arn]
+          ContainerName: "retool-workflows-backend"
+          ContainerPort: 3000
+      Cluster: !Ref 'Cluster'
+      DesiredCount: !Ref 'DesiredCount'
+      DeploymentConfiguration:
+        MaximumPercent: !Ref 'MaximumPercent'
+        MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
+      TaskDefinition: !Ref 'RetoolWorkkflowsBackendTask'
+
+  RetoolServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: [ecs.amazonaws.com]
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies:
+      - PolicyName: !Join ['-', ['Retool', !Ref 'Environment', 'service-policy']]
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: [
+              'elasticloadbalancing:DeregisterInstancesFromLoadBalancer',
+              'elasticloadbalancing:DeregisterTargets',
+              'elasticloadbalancing:Describe*',
+              'elasticloadbalancing:RegisterInstancesWithLoadBalancer',
+              'elasticloadbalancing:RegisterTargets',
+              'ec2:Describe*',
+              'ec2:AuthorizeSecurityGroupIngress']
+            Resource: '*'
+
+  RetoolTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: ['ecs-tasks.amazonaws.com']
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies: []
+
+# Workflows
+  WorkflowsCloudMapNamespace:
+    Type: AWS::ServiceDiscovery::PrivateDnsNamespace
+    Properties:
+      Name: retoolsvc
+      Vpc: !Ref 'VpcId'
+  RetoolWorkflowBackendServiceCloudmapService:
+    Type: AWS::ServiceDiscovery::Service
+    Properties:
+      DnsConfig:
+        DnsRecords:
+          - TTL: 60
+            Type: A
+        NamespaceId: !GetAtt [WorkflowsCloudMapNamespace, Id]
+        RoutingPolicy: MULTIVALUE
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: workflows-backend
+      NamespaceId: !GetAtt [WorkflowsCloudMapNamespace, Id]
+
+
+# Temporal
+  RetoolTemporalTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: ['ecs-tasks.amazonaws.com']
+          Action: ['sts:AssumeRole']
+      Path: /
+      Policies: []
+  RetoolTemporalRDSSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: 'This is the secret for the Retool Temporal RDS instance'
+      GenerateSecretString:
+        SecretStringTemplate: '{"username": "retool"}'
+        GenerateStringKey: 'password'
+        PasswordLength: 16
+        ExcludeCharacters: '"@/\'
+
+  # RDS-based Temporal DB
+  # RetoolTemporalRDSInstance:
+  #   Type: AWS::RDS::DBInstance
+  #   Properties:
+  #     AllocatedStorage: "80"
+  #     DBInstanceClass: "db.m4.large"
+  #     Engine: postgres
+  #     EngineVersion: "11.12"
+  #     DBName: "temporal"
+  #     MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:username}}' ]]
+  #     MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:password}}' ]]
+  #     Port: "5432"
+  #     VPCSecurityGroups: [!GetAtt [RDSSecurityGroup, GroupId]]
+  #     DBSubnetGroupName: !Ref 'RDSSubnetGroup'
+
+  # Aurora-based Temporal DB
+  RetoolTemporalRDSCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      Engine: "aurora-postgresql"
+      EngineVersion: "14.5"
+      MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:username}}' ]]
+      MasterUserPassword: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:password}}' ]]
+      Port: "5432"
+      VpcSecurityGroupIds: [!GetAtt [RDSSecurityGroup, GroupId]]
+      DBSubnetGroupName: !Ref 'RDSSubnetGroup'
+      ServerlessV2ScalingConfiguration:
+        MinCapacity: 0.5
+        MaxCapacity: 10
+  RetoolTemporalRDSInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      Engine: "aurora-postgresql"
+      DBInstanceClass: "db.serverless"
+      DBClusterIdentifier: !Ref 'RetoolTemporalRDSCluster'
+
+  TemporalClusterFrontendTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool-temporal-frontend'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+        - Name: temporal-cluster-frontend
+          Cpu: '256'
+          Memory: '512'
+          Essential: 'true'
+          Image: tryretool/one-offs:retool-temporal-1.1.2
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref 'CloudwatchLogsGroup'
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: "SERVICE_RETOOL_TEMPORAL"
+          Environment:
+            - Name: SERVICES
+              Value: frontend
+            - Name: LOG_LEVEL
+              Value: debug,info
+            - Name: NUM_HISTORY_SHARDS
+              Value: "128"
+            - Name: DB
+              Value: postgresql
+            - Name: POSTGRES_HOST
+              Value: !GetAtt [RetoolTemporalRDSInstance, Endpoint.Address]
+            - Name: POSTGRES_PORT
+              Value: 5432
+            - Name: POSTGRES_USER
+              Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:username}}' ]]
+            - Name: POSTGRES_PASSWORD
+              Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:password}}' ]]
+            # - Name: SQL_TLS_ENABLED
+            #   Value: "true"
+            # - Name: SQL_TLS
+            #   Value: "true"
+            # - Name: SQL_TLS_SKIP_HOST_VERIFICATION
+            #   Value: "true"
+            # - Name: SQL_TLS_DISABLE_HOST_VERIFICATION
+            #   Value: "true"
+            - Name: DBNAME
+              Value: temporal
+            - Name: DBNAME_VISIBILITY
+              Value: temporal_visibility
+            - Name: DYNAMIC_CONFIG_FILE_PATH
+              Value: /etc/temporal/ecs/dynamic_config/dynamicconfig-sql.yaml
+            - Name: ECS_DEPLOYED
+              Value: "true"
+          PortMappings:
+            - ContainerPort: 7233
+              HostPort: 7233
+              Protocol: tcp
+            - ContainerPort: 6933
+              HostPort: 6933
+              Protocol: tcp
+  TemporalClusterHistoryTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool-temporal-history'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+        - Name: temporal-cluster-history
+          Cpu: '512'
+          Memory: '1024'
+          Essential: 'true'
+          Image: tryretool/one-offs:retool-temporal-1.1.2
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref 'CloudwatchLogsGroup'
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: "SERVICE_RETOOL_TEMPORAL"
+          Environment:
+            - Name: SERVICES
+              Value: history
+            - Name: LOG_LEVEL
+              Value: debug,info
+            - Name: NUM_HISTORY_SHARDS
+              Value: "128"
+            - Name: DB
+              Value: postgresql
+            - Name: POSTGRES_HOST
+              Value: !GetAtt [RetoolTemporalRDSInstance, Endpoint.Address]
+            - Name: POSTGRES_PORT
+              Value: 5432
+            - Name: POSTGRES_USER
+              Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:username}}' ]]
+            - Name: POSTGRES_PASSWORD
+              Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:password}}' ]]
+            # - Name: SQL_TLS_ENABLED
+            #   Value: "true"
+            # - Name: SQL_TLS
+            #   Value: "true"
+            # - Name: SQL_TLS_SKIP_HOST_VERIFICATION
+            #   Value: "true"
+            # - Name: SQL_TLS_DISABLE_HOST_VERIFICATION
+            #   Value: "true"
+            - Name: DBNAME
+              Value: temporal
+            - Name: DBNAME_VISIBILITY
+              Value: temporal_visibility
+            - Name: DYNAMIC_CONFIG_FILE_PATH
+              Value: /etc/temporal/ecs/dynamic_config/dynamicconfig-sql.yaml
+            - Name: PUBLIC_FRONTEND_ADDRESS
+              Value: temporal.retoolsvc:7233
+            - Name: ECS_DEPLOYED
+              Value: "true"
+          PortMappings:
+            - ContainerPort: 7234
+              HostPort: 7234
+              Protocol: tcp
+            - ContainerPort: 6934
+              HostPort: 6934
+              Protocol: tcp
+  TemporalClusterMatchingTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool-temporal-matching'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+        - Name: temporal-cluster-matching
+          Cpu: '512'
+          Memory: '1024'
+          Essential: 'true'
+          Image: tryretool/one-offs:retool-temporal-1.1.2
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref 'CloudwatchLogsGroup'
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: "SERVICE_RETOOL_TEMPORAL"
+          Environment:
+            - Name: SERVICES
+              Value: matching
+            - Name: LOG_LEVEL
+              Value: debug,info
+            - Name: NUM_HISTORY_SHARDS
+              Value: "128"
+            - Name: DB
+              Value: postgresql
+            - Name: POSTGRES_HOST
+              Value: !GetAtt [RetoolTemporalRDSInstance, Endpoint.Address]
+            - Name: POSTGRES_PORT
+              Value: 5432
+            - Name: POSTGRES_USER
+              Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:username}}' ]]
+            - Name: POSTGRES_PASSWORD
+              Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:password}}' ]]
+            # - Name: SQL_TLS_ENABLED
+            #   Value: "true"
+            # - Name: SQL_TLS
+            #   Value: "true"
+            # - Name: SQL_TLS_SKIP_HOST_VERIFICATION
+            #   Value: "true"
+            # - Name: SQL_TLS_DISABLE_HOST_VERIFICATION
+            #   Value: "true"
+            - Name: DBNAME
+              Value: temporal
+            - Name: DBNAME_VISIBILITY
+              Value: temporal_visibility
+            - Name: DYNAMIC_CONFIG_FILE_PATH
+              Value: /etc/temporal/ecs/dynamic_config/dynamicconfig-sql.yaml
+            - Name: PUBLIC_FRONTEND_ADDRESS
+              Value: temporal.retoolsvc:7233
+            - Name: ECS_DEPLOYED
+              Value: "true"
+          PortMappings:
+            - ContainerPort: 7235
+              HostPort: 7235
+              Protocol: tcp
+            - ContainerPort: 6935
+              HostPort: 6935
+              Protocol: tcp
+  TemporalClusterWorkerTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool-temporal-worker'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+        - Name: temporal-cluster-worker
+          Cpu: '256'
+          Memory: '512'
+          Essential: 'true'
+          Image: tryretool/one-offs:retool-temporal-1.1.2
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref 'CloudwatchLogsGroup'
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: "SERVICE_RETOOL_TEMPORAL"
+          Environment:
+            - Name: SERVICES
+              Value: worker
+            - Name: LOG_LEVEL
+              Value: debug,info
+            - Name: NUM_HISTORY_SHARDS
+              Value: "128"
+            - Name: DB
+              Value: postgresql
+            - Name: POSTGRES_HOST
+              Value: !GetAtt [RetoolTemporalRDSInstance, Endpoint.Address]
+            - Name: POSTGRES_PORT
+              Value: 5432
+            - Name: POSTGRES_USER
+              Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:username}}' ]]
+            - Name: POSTGRES_PASSWORD
+              Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolTemporalRDSSecret, ':SecretString:password}}' ]]
+            # - Name: SQL_TLS_ENABLED
+            #   Value: "true"
+            # - Name: SQL_TLS
+            #   Value: "true"
+            # - Name: SQL_TLS_SKIP_HOST_VERIFICATION
+            #   Value: "true"
+            # - Name: SQL_TLS_DISABLE_HOST_VERIFICATION
+            #   Value: "true"
+            - Name: DBNAME
+              Value: temporal
+            - Name: DBNAME_VISIBILITY
+              Value: temporal_visibility
+            - Name: DYNAMIC_CONFIG_FILE_PATH
+              Value: /etc/temporal/ecs/dynamic_config/dynamicconfig-sql.yaml
+            - Name: PUBLIC_FRONTEND_ADDRESS
+              Value: temporal.retoolsvc:7233
+            - Name: ECS_DEPLOYED
+              Value: "true"
+          PortMappings:
+            - ContainerPort: 7239
+              HostPort: 7239
+              Protocol: tcp
+            - ContainerPort: 6939
+              HostPort: 6939
+              Protocol: tcp
+  TemporalClusterWebTask:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: 'retool-temporal-web'
+      TaskRoleArn: !Ref 'RetoolTaskRole'
+      ContainerDefinitions:
+        - Name: temporal-cluster-web
+          Cpu: '256'
+          Memory: '512'
+          Image: temporalio/ui:2.14.0
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref 'CloudwatchLogsGroup'
+              awslogs-region: !Ref 'AWS::Region'
+              awslogs-stream-prefix: "SERVICE_RETOOL_TEMPORAL"
+          Environment:
+            - Name: TEMPORAL_ADDRESS
+              Value: temporal.retoolsvc:7233
+          PortMappings:
+            - ContainerPort: 8088
+              HostPort: 8088
+              Protocol: tcp
+  TemporalFrontendService:
+    Type: AWS::ECS::Service
+    Properties:
+      ServiceRegistries:
+        - RegistryArn: !GetAtt [TemporalFrontendCloudmapService, Arn]
+          ContainerName: "retool-temporal-frontend"
+          ContainerPort: 7233
+      Cluster: !Ref 'Cluster'
+      DesiredCount: !Ref 'DesiredCount'
+      DeploymentConfiguration:
+        MaximumPercent: !Ref 'MaximumPercent'
+        MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
+      TaskDefinition: !Ref 'TemporalClusterFrontendTask'
+  TemporalHistoryService:
+    Type: AWS::ECS::Service
+    DependsOn: TemporalFrontendService
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: !Ref 'DesiredCount'
+      DeploymentConfiguration:
+        MaximumPercent: !Ref 'MaximumPercent'
+        MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
+      TaskDefinition: !Ref 'TemporalClusterHistoryTask'
+  TemporalMatchingService:
+    Type: AWS::ECS::Service
+    DependsOn: TemporalFrontendService
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: !Ref 'DesiredCount'
+      DeploymentConfiguration:
+        MaximumPercent: !Ref 'MaximumPercent'
+        MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
+      TaskDefinition: !Ref 'TemporalClusterMatchingTask'
+  TemporalWorkerService:
+    Type: AWS::ECS::Service
+    DependsOn: TemporalFrontendService
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: !Ref 'DesiredCount'
+      DeploymentConfiguration:
+        MaximumPercent: !Ref 'MaximumPercent'
+        MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
+      TaskDefinition: !Ref 'TemporalClusterWorkerTask'
+  TemporalClusterWebService:
+    Type: AWS::ECS::Service
+    DependsOn: TemporalFrontendService
+    Properties:
+      Cluster: !Ref 'Cluster'
+      DesiredCount: !Ref 'DesiredCount'
+      DeploymentConfiguration:
+        MaximumPercent: !Ref 'MaximumPercent'
+        MinimumHealthyPercent: !Ref 'MinimumHealthyPercent'
+      TaskDefinition: !Ref 'TemporalClusterWebTask'
+  TemporalFrontendCloudmapService:
+    Type: AWS::ServiceDiscovery::Service
+    Properties:
+      DnsConfig:
+        DnsRecords:
+          - TTL: 60
+            Type: A
+        NamespaceId: !GetAtt [WorkflowsCloudMapNamespace, Id]
+        RoutingPolicy: MULTIVALUE
+      HealthCheckCustomConfig:
+        FailureThreshold: 1
+      Name: temporal
+      NamespaceId: !GetAtt [WorkflowsCloudMapNamespace, Id]
+
+Outputs:
+  ECSALB:
+    Description: Your ALB DNS URL
+    Value: !GetAtt [ECSALB, DNSName]


### PR DESCRIPTION
Adds support for Workflows deployment on ECS with EC2 compute. This setup requires a VPC with at least two private and public subnets. All the EC2 instances and containers run inside the private subnets (with NAT gateway in public subnet for internet access) and the Application Load Balancer runs in the public subnet to route traffic to retool-api container.
This is a slight departure from our non-Workflows template because we use awsvpc networkMode instead of bridge, this simplifies how we treat our Temporal containers, which need to broadcast their own address for inter-communication.