### PR TITLE
use GetAtt instead of Ref for security group id

### DIFF
--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -47,7 +47,7 @@ Resources:
   GlobalHttpInbound:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'ALBSecurityGroup'
+      GroupId: !GetAtt [ALBSecurityGroup, GroupId]
       IpProtocol: tcp
       FromPort: '80'
       ToPort: '80'
@@ -62,18 +62,18 @@ Resources:
   ALBInbound:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'RetoolSecurityGroup'
+      GroupId: !GetAtt [RetoolSecurityGroup, GroupId]
       IpProtocol: tcp
       FromPort: '3000'
       ToPort: '3000'
-      SourceSecurityGroupId: !Ref 'ALBSecurityGroup'
+      SourceSecurityGroupId: !GetAtt [ALBSecurityGroup, GroupId]
 
   RetoolSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'RetoolSecurityGroup'
+      GroupId: !GetAtt [RetoolSecurityGroup, GroupId]
       IpProtocol: -1
-      SourceSecurityGroupId: !Ref 'RetoolSecurityGroup'
+      SourceSecurityGroupId: !GetAtt [RetoolSecurityGroup, GroupId]
 
   TemporalSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -88,18 +88,18 @@ Resources:
   TemporalFrontendIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'TemporalSecurityGroup'
+      GroupId: !GetAtt [TemporalSecurityGroup, GroupId]
       IpProtocol: tcp
       FromPort: 7233
       ToPort: 7233
-      SourceSecurityGroupId: !Ref 'RetoolSecurityGroup'
+      SourceSecurityGroupId: !GetAtt [RetoolSecurityGroup, GroupId]
 
   TemporalSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'TemporalSecurityGroup'
+      GroupId: !GetAtt [TemporalSecurityGroup, GroupId]
       IpProtocol: -1
-      SourceSecurityGroupId: !Ref 'TemporalSecurityGroup'
+      SourceSecurityGroupId: !GetAtt [TemporalSecurityGroup, GroupId]
 
 
   CloudwatchLogsGroup:
@@ -392,7 +392,7 @@ Resources:
       - Key: idle_timeout.timeout_seconds
         Value: '60'
       Subnets: !Ref 'ALBSubnetId'
-      SecurityGroups: [!Ref 'ALBSecurityGroup']
+      SecurityGroups: [!GetAtt [ALBSecurityGroup, GroupId]]
 
   ALBListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -444,7 +444,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'RetoolSecurityGroup']
+          SecurityGroups: [!GetAtt [RetoolSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
@@ -463,7 +463,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'RetoolSecurityGroup']
+          SecurityGroups: [!GetAtt [RetoolSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: 1
@@ -475,7 +475,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'RetoolSecurityGroup']
+          SecurityGroups: [!GetAtt [RetoolSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredWorkflowsCount'
@@ -491,7 +491,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'RetoolSecurityGroup']
+          SecurityGroups: [!GetAtt [RetoolSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       ServiceRegistries:
         - RegistryArn: !GetAtt [RetoolWorkflowBackendServiceCloudmapService, Arn]
@@ -886,7 +886,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       ServiceRegistries:
         - RegistryArn: !GetAtt [TemporalFrontendCloudmapService, Arn]
@@ -903,7 +903,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredWorkflowsCount'
@@ -918,7 +918,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredWorkflowsCount'
@@ -933,7 +933,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: 1
@@ -948,7 +948,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED # must be run in private subnet with NAT gateway
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: 1

--- a/cloudformation/retool-workflows.fargate.yaml
+++ b/cloudformation/retool-workflows.fargate.yaml
@@ -47,7 +47,7 @@ Resources:
   GlobalHttpInbound:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'ALBSecurityGroup'
+      GroupId: !GetAtt [ALBSecurityGroup, GroupId]
       IpProtocol: tcp
       FromPort: '80'
       ToPort: '80'
@@ -62,18 +62,18 @@ Resources:
   ALBInbound:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'RetoolSecurityGroup'
+      GroupId: !GetAtt [RetoolSecurityGroup, GroupId]
       IpProtocol: tcp
       FromPort: '3000'
       ToPort: '3000'
-      SourceSecurityGroupId: !Ref 'ALBSecurityGroup'
+      SourceSecurityGroupId: !GetAtt [ALBSecurityGroup, GroupId]
 
   RetoolSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'RetoolSecurityGroup'
+      GroupId: !GetAtt [RetoolSecurityGroup, GroupId]
       IpProtocol: -1
-      SourceSecurityGroupId: !Ref 'RetoolSecurityGroup'
+      SourceSecurityGroupId: !GetAtt [RetoolSecurityGroup, GroupId]
     
   TemporalSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -88,18 +88,18 @@ Resources:
   TemporalFrontendIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'TemporalSecurityGroup'
+      GroupId: !GetAtt [TemporalSecurityGroup, GroupId]
       IpProtocol: tcp
       FromPort: 7233
       ToPort: 7233
-      SourceSecurityGroupId: !Ref 'RetoolSecurityGroup'
+      SourceSecurityGroupId: !GetAtt [RetoolSecurityGroup, GroupId]
 
   TemporalSelfIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref 'TemporalSecurityGroup'
+      GroupId: !GetAtt [TemporalSecurityGroup, GroupId]
       IpProtocol: -1
-      SourceSecurityGroupId: !Ref 'TemporalSecurityGroup'
+      SourceSecurityGroupId: !GetAtt [TemporalSecurityGroup, GroupId]
 
 
   CloudwatchLogsGroup:
@@ -402,7 +402,7 @@ Resources:
       - Key: idle_timeout.timeout_seconds
         Value: '60'
       Subnets: !Ref 'ALBSubnetId'
-      SecurityGroups: [!Ref 'ALBSecurityGroup']
+      SecurityGroups: [!GetAtt [ALBSecurityGroup, GroupId]]
 
   ALBListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
@@ -454,7 +454,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'RetoolSecurityGroup']
+          SecurityGroups: [!GetAtt [RetoolSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredCount'
@@ -474,7 +474,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'RetoolSecurityGroup']
+          SecurityGroups: [!GetAtt [RetoolSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: 1
@@ -487,7 +487,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'RetoolSecurityGroup']
+          SecurityGroups: [!GetAtt [RetoolSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredWorkflowsCount'
@@ -504,7 +504,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'RetoolSecurityGroup']
+          SecurityGroups: [!GetAtt [RetoolSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       ServiceRegistries:
         - RegistryArn: !GetAtt [RetoolWorkflowBackendFargateServiceCloudmapService, Arn]
@@ -941,7 +941,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       ServiceRegistries:
         - RegistryArn: !GetAtt [TemporalFrontendCloudmapService, Arn]
@@ -959,7 +959,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredWorkflowsCount'
@@ -975,7 +975,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: !Ref 'DesiredWorkflowsCount'
@@ -991,7 +991,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: 1
@@ -1007,7 +1007,7 @@ Resources:
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: ENABLED
-          SecurityGroups: [!Ref 'TemporalSecurityGroup']
+          SecurityGroups: [!GetAtt [TemporalSecurityGroup, GroupId]]
           Subnets: !Ref 'SubnetId'
       Cluster: !Ref 'Cluster'
       DesiredCount: 1


### PR DESCRIPTION
Using !Ref for security group ID seems to only work sometimes (has been successful internal + at least 1 confirmed customer, but have 1 case of !Ref returning the security group name instead of ID) -- so let's explicitly fetch the GroupId attribute when needed