### PR TITLE
Update docker_setup

### DIFF
--- a/docker_setup
+++ b/docker_setup
@@ -2,7 +2,7 @@
 
 postgresPassword=$(cat /dev/urandom | base64 | head -c 64)
 retooldbPostgresPassword=$(cat /dev/urandom | base64 | head -c 64)
-jwtSecret=$(cat /dev/urandom | base64 | head -c 256)
+jwtSecret=$(cat /dev/urandom | base64 | head -c 256 | tr -d '\n')
 encryptionKey=$(cat /dev/urandom | base64 | head -c 64)
 publicIpAddress=$(dig +short myip.opendns.com @resolver1.opendns.com)
 


### PR DESCRIPTION
`base64` outputs a multiline string.

`JWT_SECRET` part in `docker.env` looks like this:
```
JWT_SECRET=CUUFOda1RFKQm+yn7lonersUsLtiCo+fU+NCnbjGAvRj5YQzMOXC8CUWg5OVWyCPw/5g6Ez4sqfZ
MkQg1FlmWenhqmdbxCkWe5rwl4IK1286H+uXvVw+Uz5uzZyyTVTTQl57TLPAjbRsxPGnSXFxf/2r
uuDCp75NKfRZvItL0GW8SiVhTUwWW0mo1WhYGsDGZ3rljThK8FunxNyd9l/c6hG9ETt6uFCQVx/H
N/Iu7nkbp/zPzrK8mXfKrumL6
```

Then, `docker-compose` can't load such `docker.env` because of `+` symbol.