### PR TITLE
Adds code-executor for workflows

### DIFF
--- a/kubernetes_workflows/retool-code-executor-container.yaml
+++ b/kubernetes_workflows/retool-code-executor-container.yaml
@@ -1,4 +1,4 @@
-piVersion: apps/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -30,9 +30,6 @@ spec:
             - containerPort: 3004
               name: retool
               protocol: TCP
-            - containerPort: 9090
-              name: metrics
-              protocol: TCP
           resources:
             limits:
               cpu: 2000m
@@ -40,3 +37,5 @@ spec:
             requests:
               cpu: 1000m
               memory: 1024Mi
+          securityContext:
+            privileged: true

--- a/kubernetes_workflows/retool-code-executor-container.yaml
+++ b/kubernetes_workflows/retool-code-executor-container.yaml
@@ -1,0 +1,42 @@
+piVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    retoolService: code-executor
+  name: code-executor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      retoolService: code-executor
+  revisionHistoryLimit: 3
+  template:
+    metadata:
+      labels:
+        retoolService: code-executor
+    spec:
+      containers:
+        - args:
+            - bash
+            - start.sh
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: NODE_OPTIONS
+              value: --max_old_space_size=1024
+          image: tryretool/code-executor-service:X.Y.Z
+          name: code-executor
+          ports:
+            - containerPort: 3004
+              name: retool
+              protocol: TCP
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2048Mi
+            requests:
+              cpu: 1000m
+              memory: 1024Mi

--- a/kubernetes_workflows/retool-container.yaml
+++ b/kubernetes_workflows/retool-container.yaml
@@ -71,6 +71,8 @@ spec:
           value: "workflows"
         - name: WORKFLOW_BACKEND_HOST
           value: http://workflows-api
+        - name: CODE_EXECUTOR_INGRESS_DOMAIN
+          value: http://code-executor
         image: tryretool/backend:X.Y.Z
         name: api
         ports:

--- a/kubernetes_workflows/retool-container.yaml
+++ b/kubernetes_workflows/retool-container.yaml
@@ -72,7 +72,7 @@ spec:
         - name: WORKFLOW_BACKEND_HOST
           value: http://workflows-api
         - name: CODE_EXECUTOR_INGRESS_DOMAIN
-          value: http://code-executor
+          value: http://code-executor:3004
         image: tryretool/backend:X.Y.Z
         name: api
         ports:

--- a/kubernetes_workflows/retool-workflows-backend-container.yaml
+++ b/kubernetes_workflows/retool-workflows-backend-container.yaml
@@ -71,6 +71,8 @@ spec:
           value: "workflows"
         - name: WORKFLOW_BACKEND_HOST
           value: http://workflows-api
+        - name: CODE_EXECUTOR_INGRESS_DOMAIN
+          value: http://code-executor
         image: tryretool/backend:X.Y.Z
         name: workflows-api
         ports:

--- a/kubernetes_workflows/retool-workflows-backend-container.yaml
+++ b/kubernetes_workflows/retool-workflows-backend-container.yaml
@@ -72,7 +72,7 @@ spec:
         - name: WORKFLOW_BACKEND_HOST
           value: http://workflows-api
         - name: CODE_EXECUTOR_INGRESS_DOMAIN
-          value: http://code-executor
+          value: http://code-executor:3004
         image: tryretool/backend:X.Y.Z
         name: workflows-api
         ports:

--- a/kubernetes_workflows/retool-workflows-worker-container.yaml
+++ b/kubernetes_workflows/retool-workflows-worker-container.yaml
@@ -76,6 +76,8 @@ spec:
           value: "workflows"
         - name: WORKFLOW_BACKEND_HOST
           value: http://workflows-api
+        - name: CODE_EXECUTOR_INGRESS_DOMAIN
+          value: http://code-executor
         image: tryretool/backend:X.Y.Z
         name: workflow-worker
         ports:

--- a/kubernetes_workflows/retool-workflows-worker-container.yaml
+++ b/kubernetes_workflows/retool-workflows-worker-container.yaml
@@ -77,7 +77,7 @@ spec:
         - name: WORKFLOW_BACKEND_HOST
           value: http://workflows-api
         - name: CODE_EXECUTOR_INGRESS_DOMAIN
-          value: http://code-executor
+          value: http://code-executor:3004
         image: tryretool/backend:X.Y.Z
         name: workflow-worker
         ports:


### PR DESCRIPTION
Adds `kubernetes_workflows/retool-code-executor-container.yaml` for docker-compose on-prem to spin up the code executor.