### PR TITLE
Correct use of "premises"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <b>Build internal tools, remarkably fast.</b>
 </p> <br>
 
-# Deploying Retool on-premise
+# Deploying Retool on-premises
 
 Find deployment instructions in the [official deployment guides](https://docs.retool.com/docs/deploy-guide-overview) hosted on docs.retool.com. Retool officially supports the following deployment methods:
 
@@ -18,7 +18,7 @@ Find deployment instructions in the [official deployment guides](https://docs.re
   - [ECS + Fargate](https://docs.retool.com/docs/deploy-with-ecs-fargate)
 
 
-Some previously supported deployment methods, such as Heroku and Render, are no longer a good fit for production use. You can still access these instructions in [deprecated-onpremise](https://github.com/tryretool/deprecated-onpremise) repository.
+Some previously supported deployment methods, such as Heroku and Render, are no longer a good fit for production use. You can still access these instructions in [deprecated-onpremises](https://github.com/tryretool/deprecated-onpremise) repository.
 
 
 For any inquiries regarding deploying Retool, please feel free to reach out to us at support@retool.com or search our [Community Forums](https://community.retool.com/) and post your question there.


### PR DESCRIPTION
The word "premise" (meaning the thing someone bases their argument or theory on) is often incorrectly used to describe infrastructure which is hosted on-site using the term "on-premise". The correct term for this, would be "on-premises".

I would recommend changing your repositories' names as well, although this might be a larger undertaking. I believe GitHub adds redirects for renamed repositories though.