### PR TITLE
db-connector add mising entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+    command: bash -c "./docker_scripts/start_api.sh"
     env_file: ./docker.env
     environment:
       - SERVICE_TYPE=DB_CONNECTOR_SERVICE


### PR DESCRIPTION
In a fresh deploy, when starting the db-connector service it fails because it does not have the entrypoint