### PR TITLE
[feat][DTC-5411] updated jobs runner to be able to use temporal

### DIFF
--- a/cloudformation/retool-workflows.ec2.yaml
+++ b/cloudformation/retool-workflows.ec2.yaml
@@ -223,6 +223,12 @@ Resources:
             Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
           - Name: LICENSE_KEY
             Value: "EXPIRED-LICENSE-KEY-TRIAL"
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
+            Value: temporal.retoolsvc
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
+            Value: "7233"
+          - Name: WORKFLOW_BACKEND_HOST
+            Value: http://workflows-backend.retoolsvc:3000
         Command: ["./docker_scripts/start_api.sh"]
 
   RetoolWorkkflowsBackendTask:

--- a/cloudformation/retool-workflows.fargate.yaml
+++ b/cloudformation/retool-workflows.fargate.yaml
@@ -229,6 +229,12 @@ Resources:
             Value: !Join ['', ['{{resolve:secretsmanager:', !Ref RetoolEncryptionKeySecret, ':SecretString:password}}' ]]
           - Name: LICENSE_KEY
             Value: "EXPIRED-LICENSE-KEY-TRIAL"
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
+            Value: temporal.retoolsvc
+          - Name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
+            Value: "7233"
+          - Name: WORKFLOW_BACKEND_HOST
+            Value: http://workflows-backend.retoolsvc:3000
         Command: ["./docker_scripts/start_api.sh"]
 
   RetoolWorkkflowsBackendTask:

--- a/docker-compose-workflows-with-temporal.yml
+++ b/docker-compose-workflows-with-temporal.yml
@@ -48,10 +48,15 @@ services:
     env_file: ./docker.env
     environment:
       - SERVICE_TYPE=JOBS_RUNNER
+      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
+      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
+      - WORKFLOW_BACKEND_HOST=http://api:3000
     networks:
       - backend-network
+      - workflows-network
     depends_on:
       - postgres
+      - temporal
     command: bash -c "chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh postgres:5432; ./docker_scripts/start_api.sh"
     links:
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       - DB_CONNECTOR_PORT=3002
       - DB_SSH_CONNECTOR_HOST=http://db-ssh-connector
       - DB_SSH_CONNECTOR_PORT=3002
+      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
+      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
+      - WORKFLOW_BACKEND_HOST=http://api:3000
       # If using Retool-managed Temporal cluster, leave workflow-related ENV vars commented
       # If using self-managed cluster (Temporal Cloud or self-hosted) external to your Retool deployment, uncomment and update workflow-related ENV vars
       # Compare deployment options here: https://docs.retool/self-hosted/concepts/temporal#compare-options

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       # - WORKFLOW_TEMPORAL_TLS_KEY
     networks:
       - backend-network
+      - workflows-network
     depends_on:
       - postgres
     command: bash -c "chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh postgres:5432; ./docker_scripts/start_api.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,6 @@ services:
       - DB_CONNECTOR_PORT=3002
       - DB_SSH_CONNECTOR_HOST=http://db-ssh-connector
       - DB_SSH_CONNECTOR_PORT=3002
-      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
-      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
-      - WORKFLOW_BACKEND_HOST=http://api:3000
       # If using Retool-managed Temporal cluster, leave workflow-related ENV vars commented
       # If using self-managed cluster (Temporal Cloud or self-hosted) external to your Retool deployment, uncomment and update workflow-related ENV vars
       # Compare deployment options here: https://docs.retool/self-hosted/concepts/temporal#compare-options
@@ -55,6 +52,15 @@ services:
     env_file: ./docker.env
     environment:
       - SERVICE_TYPE=JOBS_RUNNER
+      # If using Retool-managed Temporal cluster, leave workflow-related ENV vars commented
+      # If using self-managed cluster (Temporal Cloud or self-hosted) external to your Retool deployment, uncomment and update workflow-related ENV vars
+      # Compare deployment options here: https://docs.retool/self-hosted/concepts/temporal#compare-options
+      # - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
+      # - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
+      # set these if using self-managed Temporal Cloud or require TLS for your self-managed Temporal cluster
+      # - WORKFLOW_TEMPORAL_TLS_ENABLED
+      # - WORKFLOW_TEMPORAL_TLS_CRT
+      # - WORKFLOW_TEMPORAL_TLS_KEY
     networks:
       - backend-network
     depends_on:

--- a/kubernetes_workflows/retool-jobs-runner.yaml
+++ b/kubernetes_workflows/retool-jobs-runner.yaml
@@ -63,6 +63,14 @@ spec:
             secretKeyRef:
               name: retoolsecrets
               key: google_client_secret
+        - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST
+          value: "retool-temporal-frontend"
+        - name: WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT
+          value: "7233"
+        - name: WORKFLOW_TEMPORAL_CLUSTER_NAMESPACE
+          value: "workflows"
+        - name: WORKFLOW_BACKEND_HOST
+          value: http://workflows-api
         image: tryretool/backend:X.Y.Z
         name: jobs-runner
         ports:


### PR DESCRIPTION
Updating env vars for retool onpremise to allow jobs runner to access temporal and turn into a internal onprem temporal worker.

https://linear.app/retool/issue/DTC-5411/update-docker-images-with-new-jobs-runner-env-vars