### PR TITLE
add SQL_TLS envvars to temporal docker-compose definition

### DIFF
--- a/docker-compose-workflows-with-temporal.yml
+++ b/docker-compose-workflows-with-temporal.yml
@@ -155,6 +155,10 @@ services:
     environment:
       - DB=postgresql
       - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
+      # To enable TLS between temporal and external postgres, set both below variables to true
+      - SQL_TLS_ENABLED=false
+      - SQL_TLS=false
+      - SQL_TLS_DISABLE_HOST_VERIFICATION=true
     image: tryretool/one-offs:retool-temporal-1.1.2
     networks:
       - temporal-network

--- a/docker-compose-workflows-with-temporal.yml
+++ b/docker-compose-workflows-with-temporal.yml
@@ -158,7 +158,9 @@ services:
       # To enable TLS between temporal and external postgres, set both below variables to true
       - SQL_TLS_ENABLED=false
       - SQL_TLS=false
+      # Defined twice because temporal-server and temporal-sql-tool use different envvars
       - SQL_TLS_DISABLE_HOST_VERIFICATION=true
+      - SQL_HOST_VERIFICATION=false
     image: tryretool/one-offs:retool-temporal-1.1.2
     networks:
       - temporal-network


### PR DESCRIPTION
Add environment variables needed to configure TLS for connections between temporal container and external postgres persistence layer.