### PR TITLE
[fix] Only be able to run install script once

### DIFF
--- a/docker_setup
+++ b/docker_setup
@@ -22,12 +22,16 @@ if [ -z "$hostname" ]; then
 fi
 
 if [ -f ./docker.env ]; then
-  mv docker.env docker.env.$(date +"%Y-%m-%d_%H-%M-%S")
+  echo "Found existing docker.env file..."
+  echo "exiting to avoid overwriting existing the configuration file..."
+  exit 0
 fi
 touch docker.env
 
 if [ -f ./retooldb.env ]; then
-  mv retooldb.env retooldb.env.$(date +"%Y-%m-%d_%H-%M-%S")
+  echo "Found existing retooldb.env file..."
+  echo "exiting to avoid overwriting existing the configuration file..."
+  exit 0
 fi
 touch retooldb.env
 

--- a/get-docker-compose.sh
+++ b/get-docker-compose.sh
@@ -1,2 +1,8 @@
+if command -v docker-compose &> /dev/null ; then
+    echo "docker-compose is already installed..."
+    echo "skipping installing docker-compose..."
+    exit 0
+fi
+
 sudo -E curl -L https://github.com/docker/compose/releases/download/1.29.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose

--- a/get-docker-compose.sh
+++ b/get-docker-compose.sh
@@ -1,6 +1,6 @@
 if command -v docker-compose &> /dev/null ; then
     echo "docker-compose is already installed..."
-    echo "skipping installing docker-compose..."
+    echo "skipping docker-compose installation..."
     exit 0
 fi
 

--- a/get-docker.sh
+++ b/get-docker.sh
@@ -1,6 +1,6 @@
 if command -v docker &> /dev/null ; then
     echo "docker is already installed..."
-    echo "skipping installing docker..."
+    echo "skipping docker installation..."
     exit 0
 fi
 

--- a/get-docker.sh
+++ b/get-docker.sh
@@ -1,3 +1,9 @@
+if command -v docker &> /dev/null ; then
+    echo "docker is already installed..."
+    echo "skipping installing docker..."
+    exit 0
+fi
+
 # adapted from https://askubuntu.com/questions/459402/how-to-know-if-the-running-platform-is-ubuntu-or-centos-with-help-of-a-bash-scri
 command_present() {
   type "$1" >/dev/null 2>&1


### PR DESCRIPTION
If the install.sh script should only be run once. This now checks is docker, docker-compose, docker.env are already available and exits if they exist. It will still run the other steps that do not exist. 