### PR TITLE
Fixes docker-compose-with-temporal.yml

### DIFF
--- a/docker-compose-with-temporal.yml
+++ b/docker-compose-with-temporal.yml
@@ -214,7 +214,7 @@ services:
 
 networks:
   frontend-network:
-  backend-network::
+  backend-network:
   code-executor-network:
   temporal-network:
   intra-temporal-network:


### PR DESCRIPTION
The previous [PR](https://github.com/tryretool/retool-onpremise/pull/215) introduces a syntax error in the docker-compose-with-temporal.yml. 

This PR aims to fix that.