### PR TITLE
Update Postgres version to 15 in Docker configs

### DIFF
--- a/docker-compose-with-temporal.yml
+++ b/docker-compose-with-temporal.yml
@@ -132,7 +132,7 @@ services:
 
   # Retool's storage database. See these docs to migrate to an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
   postgres:
-    image: "postgres:15.4"
+    image: "postgres:15.12"
     env_file: docker.env
     networks:
       - backend-network
@@ -141,7 +141,7 @@ services:
       - data:/var/lib/postgresql/data
 
   retooldb-postgres:
-    image: "postgres:15.4"
+    image: "postgres:15.12"
     env_file: retooldb.env
     networks:
       - backend-network

--- a/docker-compose-with-temporal.yml
+++ b/docker-compose-with-temporal.yml
@@ -132,7 +132,7 @@ services:
 
   # Retool's storage database. See these docs to migrate to an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
   postgres:
-    image: "postgres:11.13"
+    image: "postgres:15.4"
     env_file: docker.env
     networks:
       - backend-network
@@ -141,7 +141,7 @@ services:
       - data:/var/lib/postgresql/data
 
   retooldb-postgres:
-    image: "postgres:14.3"
+    image: "postgres:15.4"
     env_file: retooldb.env
     networks:
       - backend-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
 
   # Retool's storage database. See these docs to migrate to an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
   postgres:
-    image: "postgres:11.13"
+    image: "postgres:15.4"
     env_file: docker.env
     networks:
       - backend-network
@@ -148,7 +148,7 @@ services:
       - data:/var/lib/postgresql/data
 
   retooldb-postgres:
-    image: "postgres:14.3"
+    image: "postgres:15.4"
     env_file: retooldb.env
     networks:
       - backend-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
 
   # Retool's storage database. See these docs to migrate to an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
   postgres:
-    image: "postgres:15.4"
+    image: "postgres:15.12"
     env_file: docker.env
     networks:
       - backend-network
@@ -148,7 +148,7 @@ services:
       - data:/var/lib/postgresql/data
 
   retooldb-postgres:
-    image: "postgres:15.4"
+    image: "postgres:15.12"
     env_file: retooldb.env
     networks:
       - backend-network


### PR DESCRIPTION
We've run `15.4` for a while on a few hundred internal instances, bumping this for both the internal Postgres DB Retool runs on and for the underlying database for Retool DB.  