### PR TITLE
Consolidate Dockerfiles and references to it

### DIFF
--- a/CodeExecutor.Dockerfile
+++ b/CodeExecutor.Dockerfile
@@ -1,3 +1,0 @@
-FROM tryretool/code-executor-service:X.Y.Z
-
-CMD bash start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
-FROM tryretool/backend:X.Y.Z
+# Check Dockerhub for available tags: https://hub.docker.com/r/tryretool/backend/tags
+
+ARG VERSION=X.Y.Z-stable
+
+FROM tryretool/code-executor-service:${VERSION} AS code-executor
+
+FROM tryretool/backend:${VERSION}
 
 CMD ./docker_scripts/start_api.sh

--- a/docker-compose-with-temporal.yml
+++ b/docker-compose-with-temporal.yml
@@ -4,7 +4,6 @@ services:
   api:
     build:
       context: ./
-      dockerfile: Dockerfile
     env_file: ./docker.env
     environment:
       - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
@@ -36,7 +35,6 @@ services:
   jobs-runner:
     build:
       context: ./
-      dockerfile: Dockerfile
     env_file: ./docker.env
     environment:
       - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
@@ -52,7 +50,6 @@ services:
   workflows-worker:
     build:
       context: ./
-      dockerfile: Dockerfile
     command: bash -c "./docker_scripts/wait-for-it.sh postgres:5432; ./docker_scripts/start_api.sh"
     env_file: ./docker.env
     depends_on:
@@ -74,7 +71,6 @@ services:
   workflows-backend:
     build:
       context: ./
-      dockerfile: Dockerfile
     env_file: ./docker.env
     environment:
       - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
@@ -99,7 +95,7 @@ services:
   code-executor:
     build:
       context: ./
-      dockerfile: CodeExecutor.Dockerfile
+      target: code-executor
     command: bash -c "./start.sh"
     env_file: ./docker.env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   api:
     build:
       context: ./
-      dockerfile: Dockerfile
     env_file: ./docker.env
     environment:
       - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
@@ -40,7 +39,6 @@ services:
   jobs-runner:
     build:
       context: ./
-      dockerfile: Dockerfile
     env_file: ./docker.env
     environment:
       - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
@@ -56,7 +54,6 @@ services:
   workflows-worker:
     build:
       context: ./
-      dockerfile: Dockerfile
     command: bash -c "./docker_scripts/wait-for-it.sh postgres:5432; ./docker_scripts/start_api.sh"
     env_file: ./docker.env
     environment:
@@ -83,7 +80,6 @@ services:
   workflows-backend:
     build:
       context: ./
-      dockerfile: Dockerfile
     env_file: ./docker.env
     environment:
       - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
@@ -108,7 +104,7 @@ services:
   code-executor:
     build:
       context: ./
-      dockerfile: CodeExecutor.Dockerfile
+      target: code-executor
     command: bash -c "./start.sh"
     env_file: ./docker.env
     environment:


### PR DESCRIPTION
* Get `code-executor` version through a build target in `Dockerfile` to prevent mismatched versions
* Remove `CodeExecutor.Dockerfile`
* Remove `dockerfile: Dockerfile` lines since that's the [default](https://docs.docker.com/reference/compose-file/build/)
