### PR TITLE
Better split out compose and .env configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Configure
 > [!WARNING]  
 > You must set `COOKIE_INSECURE=true` in `docker.env` to allow logging into Retool without HTTPS configured (not recommended)
 
+5. By default, the deployment will include a Temporal container for Workflows. If you have an Enterprise license and would like to instead use Retool's managed Temporal cluster, comment out the `include` block in `docker-compose.yml` and the `WORKFLOW_TEMPORAL_...` environment variables in `docker.env`. Check out [our docs](https://docs.retool.com/self-hosted/concepts/temporal) for more information on Temporal deployment options.
+
 <br>
 
 Run

--- a/docker-compose-with-temporal.yml
+++ b/docker-compose-with-temporal.yml
@@ -1,157 +1,8 @@
-# Use as is if using self-managed Temporal cluster deployed alongside Retool
-# Compare other deployment options here: https://docs.retool.com/self-hosted/concepts/temporal#compare-options
+# Self-hosted Temporal, see options at https://docs.retool.com/self-hosted/concepts/temporal#compare-options
 services:
-  api:
-    build:
-      context: ./
-    env_file: ./docker.env
-    environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
-      - SERVICE_TYPE=MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
-      - DBCONNECTOR_POSTGRES_POOL_MAX_SIZE=100
-      - DBCONNECTOR_QUERY_TIMEOUT_MS=120000
-      - WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
-      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
-      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
-      - CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
-    networks:
-      - frontend-network
-      - backend-network
-      - temporal-network
-      - code-executor-network
-    depends_on:
-      - postgres
-      - retooldb-postgres
-      - jobs-runner
-      - workflows-worker
-      - code-executor
-    command: bash -c "./docker_scripts/wait-for-it.sh postgres:5432; ./docker_scripts/start_api.sh"
-    links:
-      - postgres
-    ports:
-      - "3000:3000"
-    restart: on-failure
-
-  jobs-runner:
-    build:
-      context: ./
-    env_file: ./docker.env
-    environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
-      - SERVICE_TYPE=JOBS_RUNNER
-    networks:
-      - backend-network
-    depends_on:
-      - postgres
-    command: bash -c "chmod -R +x ./docker_scripts; sync; ./docker_scripts/wait-for-it.sh postgres:5432; ./docker_scripts/start_api.sh"
-    links:
-      - postgres
-
-  workflows-worker:
-    build:
-      context: ./
-    command: bash -c "./docker_scripts/wait-for-it.sh postgres:5432; ./docker_scripts/start_api.sh"
-    env_file: ./docker.env
-    depends_on:
-      - temporal
-    environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
-      - SERVICE_TYPE=WORKFLOW_TEMPORAL_WORKER
-      - DISABLE_DATABASE_MIGRATIONS=true
-      - WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
-      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
-      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
-      - CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
-    networks:
-      - backend-network
-      - temporal-network
-      - code-executor-network
-    restart: on-failure
-
-  workflows-backend:
-    build:
-      context: ./
-    env_file: ./docker.env
-    environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
-      - SERVICE_TYPE=WORKFLOW_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
-      - WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
-      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
-      - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
-      - CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
-    networks:
-      - backend-network
-      - temporal-network
-      - code-executor-network
-    depends_on:
-      - postgres
-      - retooldb-postgres
-      - code-executor
-    command: bash -c "./docker_scripts/wait-for-it.sh postgres:5432; ./docker_scripts/start_api.sh"
-    links:
-      - postgres
-    restart: on-failure
-
-  code-executor:
-    build:
-      context: ./
-      target: code-executor
-    command: bash -c "./start.sh"
-    env_file: ./docker.env
-    environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
-      - NODE_OPTIONS=--max_old_space_size=1024
-    networks:
-      - code-executor-network
-    # code-executor uses nsjail to sandbox code execution. nsjail requires
-    # privileged container access.
-    # If your deployment does not support privileged access, you can set this
-    # to false to not use nsjail. Without nsjail, all code is run without
-    # sandboxing within your deployment.
-    privileged: true
-    restart: on-failure
-
-  # Retool's storage database. See these docs to migrate to an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
-  postgres:
-    image: "postgres:15.12"
-    env_file: docker.env
-    networks:
-      - backend-network
-      - intra-temporal-network
-    volumes:
-      - data:/var/lib/postgresql/data
-
-  retooldb-postgres:
-    image: "postgres:15.12"
-    env_file: retooldb.env
-    networks:
-      - backend-network
-    volumes:
-      - retooldb-data:/var/lib/postgresql/data
-
-  # Not required, but leave this container to use nginx for handling the frontend & SSL certification
-  https-portal:
-    image: tryretool/https-portal:latest
-    ports:
-      - "80:80"
-      - "443:443"
-    links:
-      - api
-    restart: always
-    env_file: ./docker.env
-    environment:
-      STAGE: "local" # <- Change 'local' to 'production' to use a LetsEncrypt signed SSL cert
-      CLIENT_MAX_BODY_SIZE: 40M
-      KEEPALIVE_TIMEOUT: 605
-      PROXY_CONNECT_TIMEOUT: 600
-      PROXY_SEND_TIMEOUT: 600
-      PROXY_READ_TIMEOUT: 600
-    networks:
-      - frontend-network
-
   temporal:
-    container_name: temporal
-    env_file: ./docker.env
+    image: tryretool/one-offs:retool-temporal-1.1.6
+    env_file: docker.env
     environment:
       # To enable TLS between temporal and external postgres, set both below variables to true
       - SQL_TLS_ENABLED=false
@@ -159,43 +10,35 @@ services:
       # Defined twice because temporal-server and temporal-sql-tool use different envvars
       - SQL_TLS_DISABLE_HOST_VERIFICATION=true
       - SQL_HOST_VERIFICATION=false
-    image: tryretool/one-offs:retool-temporal-1.1.6
-    networks:
-      - intra-temporal-network
-      - temporal-network
     ports:
-      - "127.0.0.1:7233:7233"
-  temporal-admin-tools:
-    container_name: temporal-admin-tools
-    depends_on:
-      - temporal
-    environment:
-      - TEMPORAL_CLI_ADDRESS=temporal:7233
-    image: temporalio/admin-tools:1.18.5
+      - 7233:7233
     networks:
-      - intra-temporal-network
-    stdin_open: true
-    tty: true
-  temporal-ui:
-    container_name: temporal-ui
-    depends_on:
       - temporal
-    environment:
-      - TEMPORAL_ADDRESS=temporal:7233
-      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
-    image: temporalio/ui:2.9.1
-    networks:
-      - intra-temporal-network
-    ports:
-      - "8080:8080"
+  
+  # Optional Temporal tools
+
+  # temporal-admin-tools:
+  #   image: temporalio/admin-tools:1.18.5
+  #   environment:
+  #     - TEMPORAL_CLI_ADDRESS=temporal:7233
+  #   networks:
+  #     - temporal
+  #   depends_on:
+  #     - temporal
+  #   stdin_open: true
+  #   tty: true
+  
+  # temporal-ui:
+  #   image: temporalio/ui:2.9.1
+  #   environment:
+  #     - TEMPORAL_ADDRESS=temporal:7233
+  #     - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+  #   networks:
+  #     - temporal
+  #   depends_on:
+  #     - temporal
+  #   ports:
+  #     - 8080:8080
 
 networks:
-  frontend-network:
-  backend-network:
-  code-executor-network:
-  temporal-network:
-  intra-temporal-network:
-
-volumes:
-  data:
-  retooldb-data:
+  temporal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,14 @@
+# We recommend Retool-managed Temporal for Workflows, uncomment below if you need to self-host your own cluster
+# include:
+#   - temporal.yaml
+
 services:
   api:
     build:
       context: .
     env_file: docker.env
     environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
       - SERVICE_TYPE=MAIN_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
-      - DBCONNECTOR_POSTGRES_POOL_MAX_SIZE=100
-      - DBCONNECTOR_QUERY_TIMEOUT_MS=120000
-      - WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
-      - CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
-      # If using Retool-managed Temporal cluster, leave workflow-related ENV vars commented
-      # If using self-managed cluster (Temporal Cloud or self-hosted) external to your Retool deployment, uncomment and update workflow-related ENV vars
-      # Compare deployment options here: https://docs.retool.com/self-hosted/concepts/temporal#compare-options
-      # - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
-      # - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
-      # set these if using self-managed Temporal Cloud or require TLS for your self-managed Temporal cluster
-      # - WORKFLOW_TEMPORAL_TLS_ENABLED
-      # - WORKFLOW_TEMPORAL_TLS_CRT
-      # - WORKFLOW_TEMPORAL_TLS_KEY
     ports:
       - 3000:3000
     networks:
@@ -27,83 +17,61 @@ services:
       - code-executor
     depends_on:
       - postgres
-    restart: on-failure
+    restart: always
 
   jobs-runner:
     build:
       context: .
     env_file: docker.env
     environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
       - SERVICE_TYPE=JOBS_RUNNER
     networks:
       - backend
     depends_on:
       - postgres
+    restart: always
 
   workflows-worker:
     build:
       context: .
     env_file: docker.env
     environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
       - SERVICE_TYPE=WORKFLOW_TEMPORAL_WORKER
       - NODE_OPTIONS=--max_old_space_size=1024
-      - DISABLE_DATABASE_MIGRATIONS=true
-      - WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
-      - CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
-      # If using Retool-managed Temporal cluster, leave workflow-related ENV vars commented
-      # If using self-managed cluster (Temporal Cloud or self-hosted) external to your Retool deployment, uncomment and update workflow-related ENV vars
-      # Compare deployment options here: https://docs.retool.com/self-hosted/concepts/temporal#compare-options
-      # - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
-      # - WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
-      # set these if using self-managed Temporal Cloud or require TLS for your self-managed Temporal cluster
-      # - WORKFLOW_TEMPORAL_TLS_ENABLED
-      # - WORKFLOW_TEMPORAL_TLS_CRT
-      # - WORKFLOW_TEMPORAL_TLS_KEY
     networks:
       - backend
       - code-executor
     depends_on:
       - postgres
-    restart: on-failure
+    restart: always
 
   workflows-backend:
     build:
       context: .
     env_file: docker.env
     environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
       - SERVICE_TYPE=WORKFLOW_BACKEND,DB_CONNECTOR,DB_SSH_CONNECTOR
-      - WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
-      - CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
-      - DBCONNECTOR_POSTGRES_POOL_MAX_SIZE=100
-      - DBCONNECTOR_QUERY_TIMEOUT_MS=120000
     networks:
       - backend
       - code-executor
     depends_on:
       - postgres
-    restart: on-failure
+    restart: always
 
   code-executor:
     build:
       context: .
       target: code-executor
     environment:
-      - DEPLOYMENT_TEMPLATE_TYPE=docker-compose
       - NODE_OPTIONS=--max_old_space_size=1024
     networks:
       - code-executor
-    # code-executor uses nsjail to sandbox code execution. nsjail requires
-    # privileged container access.
-    # If your deployment does not support privileged access, you can set this
-    # to false to not use nsjail. Without nsjail, all code is run without
-    # sandboxing within your deployment.
+    # Privileged is required to sandbox user code execution and to use custom libraries
+    # Set to false if your deployment method does not allow this
     privileged: true
-    restart: on-failure
+    restart: always
 
-  # Retool's storage database. See these docs to migrate to an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
+  # Retool's internal DB, we recommend using an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
   postgres:
     image: postgres:15.12
     env_file: docker.env
@@ -111,7 +79,8 @@ services:
       - backend
     volumes:
       - data:/var/lib/postgresql/data
-
+    restart: always
+  
   retooldb-postgres:
     image: postgres:15.12
     env_file: retooldb.env
@@ -119,13 +88,15 @@ services:
       - backend
     volumes:
       - retooldb-data:/var/lib/postgresql/data
+    restart: always
 
   # Optional Nginx container for handling TLS for your domain (requires setting DOMAINS and STAGE)
   https-portal:
     image: tryretool/https-portal:latest
     env_file: docker.env
     environment:
-      STAGE: local # <- Change 'local' to 'production' to get a cert for your domain
+      # Change 'local' -> 'production' below once your domain is pointing to this server
+      STAGE: local 
       CLIENT_MAX_BODY_SIZE: 40M
       KEEPALIVE_TIMEOUT: 605
       PROXY_CONNECT_TIMEOUT: 600

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
 
   # Retool's internal DB, we recommend using an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
   postgres:
-    image: postgres:15.12
+    image: postgres:16.8
     env_file: docker.env
     networks:
       - backend
@@ -82,7 +82,7 @@ services:
     restart: always
   
   retooldb-postgres:
-    image: postgres:15.12
+    image: postgres:16.8
     env_file: retooldb.env
     networks:
       - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-# We recommend Retool-managed Temporal for Workflows, uncomment below if you need to self-host your own cluster
+# We recommend using Retool-managed Temporal for Workflows: https://docs.retool.com/self-hosted/concepts/temporal
+# If you need to self-host, uncomment below and the WORKFLOW_TEMPORAL_* environment variables in docker.env
 # include:
 #   - temporal.yaml
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-# We recommend using Retool-managed Temporal for Workflows: https://docs.retool.com/self-hosted/concepts/temporal
-# If you need to self-host, uncomment below and the WORKFLOW_TEMPORAL_* environment variables in docker.env
-# include:
-#   - temporal.yaml
+# Comment out the below 'include' block to use Retool-managed Temporal (Enterprise license)
+include:
+  - temporal.yaml
 
 services:
   api:

--- a/install.sh
+++ b/install.sh
@@ -78,9 +78,9 @@ RETOOLDB_POSTGRES_PASSWORD=$(random 64)
 WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
 CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
 
-# Uncomment below only if self-hosting Temporal
-# WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
-# WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
+# Comment out below to use Retool-managed Temporal (Enterprise license)
+WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
+WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
 
 # Key to encrypt/decrypt sensitive values stored in the Postgres database
 ENCRYPTION_KEY=$(random 64)

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,7 @@ random() { cat /dev/urandom | base64 | head -c "$1" | tr -d +/ ; }
 
 cat << EOF > docker.env
 # Environment variables reference: docs.retool.com/docs/environment-variables
+DEPLOYMENT_TEMPLATE_TYPE=docker-compose
 
 # Retool's internal Postgres credentials
 POSTGRES_HOST=postgres
@@ -72,6 +73,14 @@ RETOOLDB_POSTGRES_DB=postgres
 RETOOLDB_POSTGRES_PORT=5432
 RETOOLDB_POSTGRES_USER=root
 RETOOLDB_POSTGRES_PASSWORD=$(random 64)
+
+# Workflows configuration
+WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
+CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
+
+# See Temporal options: https://docs.retool.com/self-hosted/concepts/temporal#compare-options
+WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
+WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
 
 # Key to encrypt/decrypt sensitive values stored in the Postgres database
 ENCRYPTION_KEY=$(random 64)

--- a/install.sh
+++ b/install.sh
@@ -78,9 +78,9 @@ RETOOLDB_POSTGRES_PASSWORD=$(random 64)
 WORKFLOW_BACKEND_HOST=http://workflows-backend:3000
 CODE_EXECUTOR_INGRESS_DOMAIN=http://code-executor:3004
 
-# See Temporal options: https://docs.retool.com/self-hosted/concepts/temporal#compare-options
-WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
-WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
+# Uncomment below only if self-hosting Temporal
+# WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST=temporal
+# WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT=7233
 
 # Key to encrypt/decrypt sensitive values stored in the Postgres database
 ENCRYPTION_KEY=$(random 64)
@@ -100,6 +100,7 @@ DOMAINS=$hostname -> http://api:3000
 
 # If your domain/HTTPS isn't in place yet
 # COOKIE_INSECURE=true
+
 EOF
 
 echo "✅ Created docker.env"

--- a/temporal.yaml
+++ b/temporal.yaml
@@ -1,4 +1,3 @@
-# Self-hosted Temporal, more info at https://docs.retool.com/self-hosted/concepts/temporal
 services:
   temporal:
     image: tryretool/one-offs:retool-temporal-1.1.6

--- a/temporal.yaml
+++ b/temporal.yaml
@@ -1,4 +1,4 @@
-# Self-hosted Temporal, see options at https://docs.retool.com/self-hosted/concepts/temporal#compare-options
+# Self-hosted Temporal, more info at https://docs.retool.com/self-hosted/concepts/temporal
 services:
   temporal:
     image: tryretool/one-offs:retool-temporal-1.1.6
@@ -13,6 +13,7 @@ services:
     ports:
       - 7233:7233
     networks:
+      - backend
       - temporal
   
   # Optional Temporal tools


### PR DESCRIPTION
* Absorb default workflows config into install script
* Use single compose file for Retool that optionally pulls in `temporal.yaml` if self-hosting Temporal
* Change restart policies to always for all (prevents things like DB not starting up on server restart)