### PR TITLE
update BASE_DOMAIN

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ DOMAINS=$hostname -> http://api:3000
 
 # Used to create links like user invitations and password resets
 # Retool tries to guess this, but it can be incorrect if using a proxy in front of the instance
-# BASE_DOMAIN=https://retool.company.com
+BASE_DOMAIN=https://$hostname
 
 # If your domain/HTTPS isn't in place yet
 # COOKIE_INSECURE=true


### PR DESCRIPTION
As a result of INC-2161 we are requiring customers to have the BASE_DOMAIN environment variable set. Without it, deployments of Retool are potentially vulnerable to Host Header Injection attacks, which could lead to an attacker recovering a victim's reset password token, which would allow for a full account takeover. 

This environment variable will be required beginning with stable version 3.196.0. 

We published details of this vulnerability publicly on our disclosure page at https://docs.retool.com/disclosures/cve-2025-47424. 