### PR TITLE
Up default Postgres connection max 100 -> 200 for agent preview

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -78,6 +78,7 @@ services:
   postgres:
     image: postgres:16.8
     env_file: docker.env
+    command: -c 'max_connections=200'
     networks:
       - backend
     volumes:


### PR DESCRIPTION
With new agent services adding up to an additional 20 new connections to the Postgres DB, we're more easily maxing out with the default config (especially with Temporal connecting to the same Postgres container)