### PR TITLE
Add NODE_ENV for code executor before it defaults correctly

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -63,6 +63,7 @@ services:
       context: .
       target: code-executor
     environment:
+      - NODE_ENV=production
       - NODE_OPTIONS=--max_old_space_size=1024
     networks:
       - code-executor


### PR DESCRIPTION
Before `3.225`, `code-executor` defaulted `NODE_ENV` to `development` (used for internal development) but should be `production` for any external use. The incorrect config still seems to have functioned correctly, but led to a lot of unnecessary logs. Can be removed after Q3 stable release.