### PR TITLE
Fix Kubernetes agent eval service type

### DIFF
--- a/kubernetes-with-temporal/retool-agent-eval-worker.yaml
+++ b/kubernetes-with-temporal/retool-agent-eval-worker.yaml
@@ -30,7 +30,7 @@ spec:
         - name: DEPLOYMENT_TEMPLATE_TYPE
           value: k8s-manifests
         - name: SERVICE_TYPE
-          value: WORKFLOW_TEMPORAL_WORKER
+          value: AGENT_EVAL_TEMPORAL_WORKER
         - name: WORKER_TEMPORAL_TASKQUEUE
           value: agent-eval
         - name: POSTGRES_DB

--- a/kubernetes/retool-agent-eval-worker.yaml
+++ b/kubernetes/retool-agent-eval-worker.yaml
@@ -30,7 +30,7 @@ spec:
         - name: DEPLOYMENT_TEMPLATE_TYPE
           value: k8s-manifests
         - name: SERVICE_TYPE
-          value: WORKFLOW_TEMPORAL_WORKER
+          value: AGENT_EVAL_TEMPORAL_WORKER
         - name: WORKER_TEMPORAL_TASKQUEUE
           value: agent-eval
         - name: POSTGRES_DB


### PR DESCRIPTION
`agent-worker` uses the same service type as `workflows-worker`, but `agent-eval-worker` actually uses a dedicated one.