### PR TITLE
Clarify code-executor deployment options

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -70,17 +70,10 @@ services:
     # user: retool_user
     # environment:
     #   - ALLOW_UNSAFE_CODE_EXECUTION=true
-    #   - NODE_ENV=production
-    #   - NODE_OPTIONS=--max_old_space_size=1024
-
-    environment:
-      - NODE_ENV=production
-      - NODE_OPTIONS=--max_old_space_size=1024
 
     networks:
       - code-executor
     restart: always
-
 
   # Retool's internal DB, we recommend using an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
   postgres:

--- a/compose.yaml
+++ b/compose.yaml
@@ -62,15 +62,25 @@ services:
     build:
       context: .
       target: code-executor
+    
+    # Option 1 (preferred): Run privileged to sandbox user code in Workflows
+    privileged: true
+
+    # Option 2: Run unprivileged, potentially required with your host machine permissions
+    # user: retool_user
+    # environment:
+    #   - ALLOW_UNSAFE_CODE_EXECUTION=true
+    #   - NODE_ENV=production
+    #   - NODE_OPTIONS=--max_old_space_size=1024
+
     environment:
       - NODE_ENV=production
       - NODE_OPTIONS=--max_old_space_size=1024
+
     networks:
       - code-executor
-    # Privileged is required to sandbox user code execution and to use custom libraries
-    # Set to false if your deployment method does not allow this
-    privileged: true
     restart: always
+
 
   # Retool's internal DB, we recommend using an externally hosted database: https://docs.retool.com/docs/configuring-retools-storage-database
   postgres:


### PR DESCRIPTION
* Make the deployment options for `code-executor` more explicit

* Remove env vars to use the defaults