### PR TITLE
[feat] [plat-702] Add appArmor profile loading step to installer script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ if [ -f /etc/os-release ]; then
     . /etc/os-release
     if [ "${ID}" = "ubuntu" ] && command -v dpkg &> /dev/null; then
         if dpkg --compare-versions "${VERSION_ID}" ge "24.04"; then
-            echo "  ⚠️ Ubuntu ${VERSION_ID} detected. Setting up AppArmor profile for nsjail..."
+            echo "  Ubuntu ${VERSION_ID} detected. Setting up AppArmor profile for nsjail..."
             if ! dpkg -s apparmor-profiles &> /dev/null; then
                 sudo apt-get update -y > /dev/null 2>&1 || true
                 sudo apt-get install -y apparmor-profiles > /dev/null 2>&1 || true


### PR DESCRIPTION
Update the install.sh script in to load the provided AppArmor profile if the host is Ubuntu 24 or above

Tested on an ubuntu 24.04 EC2 instance

After running install.sh the code-executor logs show successfully spawned nsjail processes
<img width="1721" height="68" alt="Screenshot 2025-12-04 at 2 55 00 PM" src="https://github.com/user-attachments/assets/6fc8bb27-83ab-4f87-a677-1ca969be6cca" />
