### PR TITLE
Add R² MCP server support to Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Configure
 
 6. By default, the deployment will include a Temporal container for Workflows. If you have an Enterprise license and would like to instead use Retool's managed Temporal cluster, comment out the `include` block in `compose.yaml` and the `WORKFLOW_TEMPORAL_...` environment variables in `docker.env`. Check out [our docs](https://docs.retool.com/self-hosted/concepts/temporal) for more information on Temporal deployment options.
 
+7. The deployment includes an `mcp` container that serves Retool's [MCP server](https://docs.retool.com/org-users/guides/mcp) at `/mcp`, letting external MCP clients connect to your instance. It needs HTTPS and the `OAUTH_MAIN_DOMAIN`, `MCP_SERVICE_EXTERNAL_URL`, and `OAUTH_INTROSPECTION_AUTH_TOKEN` variables in `docker.env` (all set by `install.sh`). The `https-portal` container routes `/mcp` to it via `CUSTOM_NGINX_SERVER_CONFIG_BLOCK`; the OAuth metadata and introspection endpoints it depends on are served by the `api` service. To disable MCP, remove the `mcp` service and that nginx block from `compose.yaml`. Point your MCP client at `https://<your-domain>/mcp`.
+
 <br>
 
 Run
@@ -93,6 +95,9 @@ Upgrade
 ------
 
 Set the new version in `Dockerfile`, and either run `./upgrade.sh` or follow the below steps:
+
+> [!NOTE]
+> The `mcp` service reads `OAUTH_MAIN_DOMAIN`, `MCP_SERVICE_EXTERNAL_URL`, and `OAUTH_INTROSPECTION_AUTH_TOKEN` from `docker.env`. `install.sh` only writes these on a fresh install, so if you are upgrading an existing deployment add them yourself (see step 7 under [Configure](#configure)). Without them the `mcp` container still starts but MCP clients fail to authenticate.
 
 1. Download and build the new images
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -282,7 +282,7 @@ services:
 
   # Optional Nginx container for handling TLS for your domain (requires setting DOMAINS and STAGE)
   https-portal:
-    image: tryretool/https-portal:latest
+    image: steveltn/https-portal:1.25.5
     env_file: docker.env
     environment:
       # Change 'local' -> 'production' below once your domain is pointing to this server

--- a/compose.yaml
+++ b/compose.yaml
@@ -321,11 +321,14 @@ services:
       PROXY_CONNECT_TIMEOUT: 600
       PROXY_SEND_TIMEOUT: 600
       PROXY_READ_TIMEOUT: 600
-      # Route the MCP protocol and its protected-resource metadata to the mcp
-      # service. Longest-prefix match wins, so these override the "/" proxy to
-      # api. OAuth metadata and /api/oauth2/introspect stay on api. $$ escapes
-      # Compose interpolation so nginx receives literal $variables. Remove this
-      # block (and the mcp service) to disable MCP.
+      # MCP routing. The api service listens on two ports: the frontend static
+      # server on 3000 (the default "/" upstream) and the backend API on 3001.
+      # The frontend server only proxies a fixed set of prefixes to the backend
+      # and serves index.html for everything else, so MCP paths must be routed
+      # explicitly here or they come back as HTML. Longest-prefix match wins, so
+      # these override the "/" proxy. $$ escapes Compose interpolation so nginx
+      # receives literal $variables. Remove this block (and the mcp service) to
+      # disable MCP.
       CUSTOM_NGINX_SERVER_CONFIG_BLOCK: |
         location /mcp {
           proxy_pass http://mcp:4010;
@@ -340,6 +343,13 @@ services:
         }
         location /.well-known/oauth-protected-resource {
           proxy_pass http://mcp:4010;
+          proxy_set_header Host $$host;
+          proxy_set_header X-Forwarded-Proto $$scheme;
+        }
+        # Straight to the backend API port (3001), bypassing the frontend
+        # server's SPA fallback, which would otherwise return index.html.
+        location = /.well-known/oauth-authorization-server {
+          proxy_pass http://api:3001;
           proxy_set_header Host $$host;
           proxy_set_header X-Forwarded-Proto $$scheme;
         }

--- a/compose.yaml
+++ b/compose.yaml
@@ -223,6 +223,31 @@ services:
         condition: service_completed_successfully
     restart: always
 
+  # Retool MCP server. Lets external MCP clients drive Retool over the Model
+  # Context Protocol. Reached at /mcp via the https-portal reverse proxy (see the
+  # CUSTOM_NGINX_SERVER_CONFIG_BLOCK below); its OAuth metadata and introspection
+  # endpoints are served by the api service. Needs OAUTH_MAIN_DOMAIN and
+  # OAUTH_INTROSPECTION_AUTH_TOKEN in docker.env, which install.sh sets up.
+  mcp:
+    build:
+      context: .
+    env_file: docker.env
+    environment:
+      - SERVICE_TYPE=MCP_SERVER
+      - MCP_PORT=4010
+      - RETOOL_BACKEND_URL=http://api:3000
+    networks:
+      # frontend so the https-portal reverse proxy can reach it at mcp:4010.
+      - frontend
+      - backend
+      - agent-sandbox
+    depends_on:
+      postgres:
+        condition: service_started
+      minio-init:
+        condition: service_completed_successfully
+    restart: always
+
   minio:
     image: minio/minio:latest
     command: server /data --console-address ":9001"
@@ -296,6 +321,27 @@ services:
       PROXY_CONNECT_TIMEOUT: 600
       PROXY_SEND_TIMEOUT: 600
       PROXY_READ_TIMEOUT: 600
+      # Route the MCP protocol and its protected-resource metadata to the mcp
+      # service. Longest-prefix match wins, so these override the "/" proxy to
+      # api. OAuth metadata and /api/oauth2/introspect stay on api. $$ escapes
+      # Compose interpolation so nginx receives literal $variables. Remove this
+      # block (and the mcp service) to disable MCP.
+      CUSTOM_NGINX_SERVER_CONFIG_BLOCK: |
+        location /mcp {
+          proxy_pass http://mcp:4010;
+          proxy_http_version 1.1;
+          proxy_set_header Host $$host;
+          proxy_set_header X-Real-IP $$remote_addr;
+          proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $$scheme;
+          proxy_buffering off;
+          proxy_read_timeout 600s;
+        }
+        location /.well-known/oauth-protected-resource {
+          proxy_pass http://mcp:4010;
+          proxy_set_header Host $$host;
+          proxy_set_header X-Forwarded-Proto $$scheme;
+        }
     ports:
       - 80:80
       - 443:443

--- a/compose.yaml
+++ b/compose.yaml
@@ -330,6 +330,7 @@ services:
         location /mcp {
           proxy_pass http://mcp:4010;
           proxy_http_version 1.1;
+          proxy_set_header Connection "";
           proxy_set_header Host $$host;
           proxy_set_header X-Real-IP $$remote_addr;
           proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;

--- a/install.sh
+++ b/install.sh
@@ -118,6 +118,8 @@ postgres_password=$(random 64)
 minio_root_user=retool
 minio_root_password=$(random 32)
 
+oauth_introspection_token=$(random 64)
+
 ae_private_pem=$(openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 2>/dev/null)
 ae_public_pem=$(echo "$ae_private_pem" | openssl ec -pubout 2>/dev/null)
 ae_private_key=$(echo "$ae_private_pem" | awk '{if(NR>1)printf "\\n";printf "%s",$0}')
@@ -194,6 +196,15 @@ DOMAINS=$hostname -> http://api:3000
 # Used to create links like user invitations and password resets
 # Retool tries to guess this, but it can be incorrect if using a proxy in front of the instance
 BASE_DOMAIN=https://$hostname
+
+# Retool MCP server (the "mcp" service). Requires HTTPS to work end to end.
+# Public host serving OAuth metadata and /api/oauth2/* (your Retool domain, no scheme)
+OAUTH_MAIN_DOMAIN=$hostname
+# Public base URL the MCP server is reachable on, used for import upload URLs
+MCP_SERVICE_EXTERNAL_URL=https://$hostname
+# Shared secret the MCP server presents to the backend's /api/oauth2/introspect.
+# Read by both the api and mcp services, so it must match on both.
+OAUTH_INTROSPECTION_AUTH_TOKEN=$oauth_introspection_token
 
 # If your domain/HTTPS isn't in place yet
 # COOKIE_INSECURE=true


### PR DESCRIPTION
## Summary

Adds R² MCP server support to the Docker Compose deployment, stacked on the HTTPS-Portal upgrade so external MCP clients can connect to a self-hosted Retool instance at `https://<domain>/mcp`.

## What changed

- Adds an `mcp` service running `SERVICE_TYPE=MCP_SERVER` on port 4010.
- Uses HTTPS-Portal's `CUSTOM_NGINX_SERVER_CONFIG_BLOCK` hook to route `/mcp` and protected-resource metadata to the MCP service, and authorization-server metadata to `api:3001`.
- Generates `OAUTH_INTROSPECTION_AUTH_TOKEN` and configures `OAUTH_MAIN_DOMAIN` and `MCP_SERVICE_EXTERNAL_URL` for fresh installs.
- Documents MCP setup and the manual environment update required for existing deployments.

## Stack

- Depends on the HTTPS-Portal image upgrade in #270.
- This PR contains no copied TLS vhost template; HTTPS-Portal continues to own its generated TLS configuration.

## Test plan

- [x] `bash -n install.sh`
- [x] `docker compose config --quiet`
- [x] Confirmed Compose renders all three custom Nginx locations and preserves literal Nginx variables.
- [x] Full stacked deployment from commit `69b3daa` on a fresh AWS sandbox EC2 host using Retool `4.0.4-stable`.
- [x] HTTPS Portal obtained a valid Let's Encrypt certificate and remained healthy with zero restarts.
- [x] Retool UI and both OAuth metadata routes return 200 over public HTTPS.
- [x] Unauthenticated `/mcp` returns 401 with the expected OAuth challenge.
- [x] Confirmed TLS 1.2 and 1.3 work and TLS 1.1 is rejected.

Temporary verification host: https://52-13-249-205.sslip.io