### PR TITLE
Upgrade HTTPS-Portal to 1.25.5

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -282,7 +282,7 @@ services:
 
   # Optional Nginx container for handling TLS for your domain (requires setting DOMAINS and STAGE)
   https-portal:
-    image: tryretool/https-portal:latest
+    image: steveltn/https-portal:1.25.5
     env_file: docker.env
     environment:
       # Change 'local' -> 'production' below once your domain is pointing to this server


### PR DESCRIPTION
## Summary

Replaces the unversioned `tryretool/https-portal:latest` image, last published in 2018, with the pinned and maintained upstream `steveltn/https-portal:1.25.5` release.

This release supports `CUSTOM_NGINX_SERVER_CONFIG_BLOCK`, allowing Compose deployments to add routes without replacing the complete generated TLS vhost template. It is a prerequisite for the stacked MCP Docker Compose change in #269.

## Test plan

- [x] Confirmed the `1.25.5` image manifest supports amd64, arm64, arm/v7, and 386.
- [x] Confirmed the tagged `default.ssl.conf.erb` renders `CUSTOM_NGINX_SERVER_CONFIG_BLOCK` before the default `location /`.
- [x] `docker compose config --quiet`
- [x] Full HTTPS deployment smoke test with stacked #269 on a fresh AWS sandbox EC2 host.
- [x] Obtained a valid Let's Encrypt certificate; HTTPS Portal is healthy with zero restarts.
- [x] Confirmed TLS 1.2 and 1.3 work and TLS 1.1 is rejected.
- [x] Confirmed injected MCP/OAuth routes coexist with the image-generated default Retool proxy.

Temporary verification host: https://52-13-249-205.sslip.io